### PR TITLE
Improvement(Jwt)!: use secrets for jwt config

### DIFF
--- a/.github/workflows/elixir_lib.yml
+++ b/.github/workflows/elixir_lib.yml
@@ -152,3 +152,4 @@ jobs:
       - uses: team-alembic/staple-actions/actions/git-ops@main
         with:
           mix-env: dev
+          no-major: true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,9 +26,6 @@ config :ash_authentication, Example,
     registry: Example.Registry
   ]
 
-config :ash_authentication, AshAuthentication.Jwt,
-  signing_secret: "Marty McFly in the past with the Delorean"
-
 config :ash_authentication,
   authentication: [
     strategies: [
@@ -41,5 +38,8 @@ config :ash_authentication,
         token_path: "/oauth/token",
         user_path: "/userinfo"
       ]
+    ],
+    tokens: [
+      signing_secret: "Marty McFly in the past with the Delorean"
     ]
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,9 +19,6 @@ config :bcrypt_elixir, :log_rounds, 4
 
 config :ash, :disable_async?, true
 
-config :ash_authentication, AshAuthentication.Jwt,
-  signing_secret: "Marty McFly in the past with the Delorean"
-
 config :ash_authentication,
   authentication: [
     strategies: [
@@ -34,5 +31,8 @@ config :ash_authentication,
         token_path: "/oauth/token",
         user_path: "/userinfo"
       ]
+    ],
+    tokens: [
+      signing_secret: "Marty McFly in the past with the Delorean"
     ]
   ]

--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -149,6 +149,14 @@ defmodule AshAuthentication.Dsl do
                 confirmations.
                 """,
                 required: true
+              ],
+              signing_secret: [
+                type: @secret_type,
+                doc: """
+                The secret used to sign tokens.
+
+                #{@secret_doc}
+                """
               ]
             ]
           },

--- a/lib/ash_authentication/secret.ex
+++ b/lib/ash_authentication/secret.ex
@@ -41,7 +41,7 @@ defmodule AshAuthentication.Secret do
 
       strategies do
         oauth2 do
-          client_id fn _secret, _resource, _opts ->
+          client_id fn _secret, _resource ->
             Application.fetch_env(:my_app, :oauth_client_id)
           end
         end

--- a/lib/ash_authentication/spark_doc_index.ex
+++ b/lib/ash_authentication/spark_doc_index.ex
@@ -56,6 +56,10 @@ defmodule AshAuthentication.SparkDocIndex do
          AshAuthentication.Strategy,
          AshAuthentication.Strategy.Password,
          AshAuthentication.Strategy.OAuth2
+       ]},
+      {"Add Ons",
+       [
+         AshAuthentication.AddOn.Confirmation
        ]}
     ]
   end

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -103,6 +103,7 @@ defmodule Example.User do
     tokens do
       enabled?(true)
       token_resource(Example.Token)
+      signing_secret(&get_config/2)
     end
 
     add_ons do


### PR DESCRIPTION
Use the `AshAuthentication.Secret` behaviour, rather than asking the user to explicitly set it in their application environment.