### PR TITLE
docs: fixed the strategy example in the `Usage` section of `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ defmodule MyApp.Accounts.User do
     api MyApp.Accounts
 
     strategies do
-      password do
+      password :password do
         identity_field :email
         hashed_password_field :hashed_password
       end

--- a/lib/ash_authentication.ex
+++ b/lib/ash_authentication.ex
@@ -28,7 +28,7 @@ defmodule AshAuthentication do
       api MyApp.Accounts
 
       strategies do
-        password do
+        password :password do
           identity_field :email
           hashed_password_field :hashed_password
         end


### PR DESCRIPTION
This PR fixes a doc error in the strategy example for an user.

Original example:

```elixir
    strategies do
      password do
        identity_field :email
        hashed_password_field :hashed_password
      end
    end
```

Correct example:

```elixir
    strategies do
      password :password do
        identity_field :email
        hashed_password_field :hashed_password
      end
    end
```


