### PR TITLE
improvement(AuthenticationFailed): store a `caused_by` value in authentication failures.

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -54,3 +54,5 @@ config :ash_authentication,
       signing_secret: "Marty McFly in the past with the Delorean"
     ]
   ]
+
+# config :ash_authentication, debug_authentication_failures?: true

--- a/lib/ash_authentication/application.ex
+++ b/lib/ash_authentication/application.ex
@@ -7,6 +7,8 @@ defmodule AshAuthentication.Application do
   @doc false
   @impl true
   def start(_type, _args) do
+    AshAuthentication.Debug.start()
+
     []
     |> maybe_append(
       start_dev_server?(),

--- a/lib/ash_authentication/debug.ex
+++ b/lib/ash_authentication/debug.ex
@@ -1,0 +1,65 @@
+defmodule AshAuthentication.Debug do
+  @moduledoc """
+  Allows you to debug authentication failures in development.
+
+  Simply add `config :ash_authentication, debug_authentication_failures?: true`
+  to your `dev.exs` and get fancy log messages when authentication fails.
+  """
+
+  alias AshAuthentication.Errors.AuthenticationFailed
+  require Logger
+  import AshAuthentication.Utils
+
+  @doc false
+  @spec start :: :ok
+  def start do
+    if enabled?() do
+      Logger.warning("""
+      Starting AshAuthentication with `debug_authentication_failres?` turned on.
+
+      You should only ever do this in your development environment for
+      debugging purposes as it will leak PII into your log.
+
+      If you do not want this on then please remove the following line from
+      your configuration:
+
+          config :ash_authentication, debug_authentication_failures?: true
+      """)
+    end
+
+    :ok
+  end
+
+  @doc false
+  @spec describe(value) :: value when value: any
+  def describe(auth_failed) when is_struct(auth_failed, AuthenticationFailed) do
+    if enabled?() do
+      message =
+        case auth_failed.caused_by do
+          exception when is_exception(exception) -> Exception.message(exception)
+          %{message: message} -> message
+          _ -> "Unknown reason"
+        end
+
+      Logger.warning("""
+      Authentication failed: #{message}
+
+      Details: #{inspect(auth_failed, limit: :infinity, printable_limit: :infinity, pretty: true)}
+      """)
+    end
+
+    auth_failed
+  end
+
+  def describe(other), do: other
+
+  @doc """
+  Has authentication debug logging been enabled?
+  """
+  @spec enabled? :: boolean
+  def enabled? do
+    :ash_authentication
+    |> Application.get_env(:debug_authentication_failures?, false)
+    |> is_truthy()
+  end
+end

--- a/lib/ash_authentication/errors/authentication_failed.ex
+++ b/lib/ash_authentication/errors/authentication_failed.ex
@@ -3,9 +3,16 @@ defmodule AshAuthentication.Errors.AuthenticationFailed do
   A generic, authentication failed error.
   """
   use Ash.Error.Exception
-  def_ash_error([], class: :forbidden)
+  def_ash_error([caused_by: %{}], class: :forbidden)
+  import AshAuthentication.Debug
 
   @type t :: Exception.t()
+
+  def exception(args) do
+    args
+    |> super()
+    |> describe()
+  end
 
   defimpl Ash.ErrorKind do
     @moduledoc false

--- a/lib/ash_authentication/strategies/password/actions.ex
+++ b/lib/ash_authentication/strategies/password/actions.ex
@@ -27,8 +27,44 @@ defmodule AshAuthentication.Strategy.Password.Actions do
     |> Query.for_read(strategy.sign_in_action_name, params)
     |> api.read(options)
     |> case do
-      {:ok, [user]} -> {:ok, user}
-      _ -> {:error, Errors.AuthenticationFailed.exception([])}
+      {:ok, [user]} ->
+        {:ok, user}
+
+      {:ok, []} ->
+        {:error,
+         Errors.AuthenticationFailed.exception(
+           caused_by: %{
+             module: __MODULE__,
+             strategy: strategy,
+             action: :sign_in,
+             message: "Query returned no users"
+           }
+         )}
+
+      {:ok, _users} ->
+        {:error,
+         Errors.AuthenticationFailed.exception(
+           caused_by: %{
+             module: __MODULE__,
+             strategy: strategy,
+             action: :sign_in,
+             message: "Query returned too many users"
+           }
+         )}
+
+      {:error, error} when is_exception(error) ->
+        {:error, Errors.AuthenticationFailed.exception(caused_by: error)}
+
+      {:error, error} ->
+        {:error,
+         Errors.AuthenticationFailed.exception(
+           caused_by: %{
+             module: __MODULE__,
+             strategy: strategy,
+             action: :sign_in,
+             message: "Query returned error: #{inspect(error)}"
+           }
+         )}
     end
   end
 


### PR DESCRIPTION
This allows for a better debugging experience when trying to understand why an authentication action is failing.

Closes #128.