### PR TITLE
Fix sign in preparation without identity resource

### DIFF
--- a/lib/ash_authentication/strategies/oauth2/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/oauth2/sign_in_preparation.ex
@@ -55,7 +55,7 @@ defmodule AshAuthentication.Strategy.OAuth2.SignInPreparation do
   end
 
   defp maybe_update_identity(user, _query, strategy) when is_falsy(strategy.identity_resource),
-    do: user
+    do: {:ok, user}
 
   defp maybe_update_identity(user, query, strategy) do
     strategy.identity_resource

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -79,6 +79,14 @@ defmodule Example.User do
       filter expr(username == get_path(^arg(:user_info), [:nickname]))
     end
 
+    read :sign_in_with_oauth2_without_identity do
+      argument :user_info, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false
+      prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
+
+      filter expr(username == get_path(^arg(:user_info), [:nickname]))
+    end
+
     create :register_with_github do
       argument :user_info, :map, allow_nil?: false
       argument :oauth_tokens, :map, allow_nil?: false
@@ -177,6 +185,19 @@ defmodule Example.User do
         authorization_params scope: "openid profile email"
         auth_method :client_secret_post
         identity_resource Example.UserIdentity
+      end
+
+      oauth2 :oauth2_without_identity do
+        client_id &get_config/2
+        redirect_uri &get_config/2
+        client_secret &get_config/2
+        site &get_config/2
+        authorize_url &get_config/2
+        token_url &get_config/2
+        user_url &get_config/2
+        authorization_params scope: "openid profile email"
+        auth_method :client_secret_post
+        registration_enabled? false
       end
 
       auth0 do


### PR DESCRIPTION
I noticed sign-in does throw an error when registration and identity resource are disabled. The test might need some work, but I couldn't override `registration_identity` in the test like this:

```elixir
strategy = %{strategy | registration_enabled?: false, identity_resource: false}
```