### PR TITLE
docs: Updates confirmation docs with sender and identities

### DIFF
--- a/lib/ash_authentication/add_ons/confirmation.ex
+++ b/lib/ash_authentication/add_ons/confirmation.ex
@@ -34,11 +34,18 @@ defmodule AshAuthentication.AddOn.Confirmation do
       add_ons do
         confirmation :confirm do
           monitor_fields [:email]
+          sender MyApp.ConfirmationSender
         end
       end
 
       strategies do
         # ...
+      end
+    end
+
+    identities do
+      identity :email, [:email] do
+        eager_check_with MyApp.Accounts
       end
     end
   end


### PR DESCRIPTION
Small hiccup in the docs for adding confirmation - not a huge blocker, but could slow folks down on adoption.