### PR TITLE
improvement: require spark ~> 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -146,7 +146,7 @@ defmodule AshAuthentication.MixProject do
   defp deps do
     [
       {:ash, ash_version("~> 2.5 and >= 2.5.11")},
-      {:spark, "~> 0.4 and >= 0.4.1 or ~> 1.0"},
+      {:spark, "~> 1.0"},
       {:jason, "~> 1.4"},
       {:joken, "~> 2.5"},
       {:plug, "~> 1.13"},


### PR DESCRIPTION
The rational is strange for this one, but I believe there is some kind of bug in dependency resolution when doing `x and y or z`, due to very cryptic errors during dependency resolution in an app for which the details I can't really share.

spark 1.0+ is stable, so lets just bump it