### PR TITLE
fix(Strategy.Password): Preparations should allow strategy to be passed in.

### DIFF
--- a/lib/ash_authentication/strategies/password/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/password/sign_in_preparation.ex
@@ -20,8 +20,8 @@ defmodule AshAuthentication.Strategy.Password.SignInPreparation do
   @doc false
   @impl true
   @spec prepare(Query.t(), keyword, Preparation.context()) :: Query.t()
-  def prepare(query, _opts, _context) do
-    strategy = Info.strategy_for_action!(query.resource, query.action.name)
+  def prepare(query, options, context) do
+    {:ok, strategy} = find_strategy(query, context, options)
     identity_field = strategy.identity_field
     identity = Query.get_argument(query, identity_field)
 
@@ -120,6 +120,21 @@ defmodule AshAuthentication.Strategy.Password.SignInPreparation do
       Resource.put_metadata(record, :token, token)
     else
       record
+    end
+  end
+
+  defp find_strategy(query, context, options) do
+    with :error <- Info.strategy_for_action(query.resource, query.action.name),
+         :error <- Map.fetch(query.context, :strategy_name),
+         :error <- Map.fetch(context, :strategy_name),
+         :error <- Keyword.fetch(options, :strategy_name) do
+      :error
+    else
+      {:ok, strategy_name} when is_atom(strategy_name) ->
+        Info.strategy(query.resource, strategy_name)
+
+      {:ok, strategy} ->
+        {:ok, strategy}
     end
   end
 end


### PR DESCRIPTION
Basically a copy-pasta of the `find_strategy/3` function from `HashPasswordChange` to allow for the strategy to be passed in via the context(s) or preparation options.