### PR TITLE
fix: fix Logger deprecations for elixir 1.15

### DIFF
--- a/lib/ash_authentication/strategies/password/password_validation.ex
+++ b/lib/ash_authentication/strategies/password/password_validation.ex
@@ -83,7 +83,7 @@ defmodule AshAuthentication.Strategy.Password.PasswordValidation do
     with :error <- Keyword.fetch(options, :strategy_name),
          :error <- Map.fetch(changeset.context, :strategy_name),
          :error <- Info.strategy_for_action(changeset.resource, changeset.action) do
-      Logger.warn(
+      Logger.warning(
         "[PasswordValidation] Unable to identify the strategy_name for `#{inspect(changeset.action)}` on `#{inspect(changeset.resource)}`."
       )
 


### PR DESCRIPTION
Use Logger.warning instead of Logger.warn, [which is deprecated as of elixir 1.15](https://github.com/elixir-lang/elixir/blob/v1.15/CHANGELOG.md#logger-2).

Logger.warning [is available since elixir 1.11](https://hexdocs.pm/logger/1.15.0/Logger.html#warning/2), and since [this project requires at least elixir 1.13](https://github.com/team-alembic/ash_authentication/blob/main/mix.exs#L12), this is a safe change.