### PR TITLE
fix: correct spec for `Jwt.token_for_user`

### DIFF
--- a/lib/ash_authentication/jwt.ex
+++ b/lib/ash_authentication/jwt.ex
@@ -84,7 +84,7 @@ defmodule AshAuthentication.Jwt do
   @doc """
   Given a user, generate a signed JWT for use while authenticating.
   """
-  @spec token_for_user(Resource.record(), extra_claims :: %{}, options :: keyword) ::
+  @spec token_for_user(Resource.record(), extra_claims :: map, options :: keyword) ::
           {:ok, token, claims} | :error
   def token_for_user(user, extra_claims \\ %{}, opts \\ []) do
     resource = user.__struct__


### PR DESCRIPTION
Should be `map` instead of `%{}` for `extra_claims`. Was getting "has no local return" from dialyzer because of this. (This is the only place where `%{}` is used instead of `map` in spec.)