### PR TITLE
fix deprecated mint httpadapter on assent

### DIFF
--- a/lib/ash_authentication/application.ex
+++ b/lib/ash_authentication/application.ex
@@ -11,6 +11,10 @@ defmodule AshAuthentication.Application do
 
     []
     |> maybe_append(
+      true,
+      {Finch, name: AshAuthentication.Finch}
+    )
+    |> maybe_append(
       start_dev_server?(),
       {AshAuthentication.Supervisor, otp_app: :ash_authentication}
     )

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -5,7 +5,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
 
   alias Ash.Error.Framework.AssumptionFailed
   alias AshAuthentication.{Errors, Info, Strategy, Strategy.OAuth2}
-  alias Assent.{Config, HTTPAdapter.Mint}
+  alias Assent.{Config, HTTPAdapter.Finch}
   alias Plug.Conn
   import Ash.PlugHelpers, only: [get_actor: 1, get_tenant: 1]
   import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
@@ -82,7 +82,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
     config =
       strategy
       |> Map.take(@raw_config_attrs)
-      |> Map.put(:http_adapter, Mint)
+      |> Map.put(:http_adapter, {Finch, supervisor: AshAuthentication.Finch})
 
     with {:ok, config} <- add_secret_value(config, strategy, :authorize_url),
          {:ok, config} <- add_secret_value(config, strategy, :client_id),


### PR DESCRIPTION
assent v0.2.6
Added [Assent.HTTPAdapter.Finch](https://hexdocs.pm/assent/Assent.HTTPAdapter.Finch.html)
Deprecated [Assent.HTTPAdapter.Mint](https://hexdocs.pm/assent/Assent.HTTPAdapter.Mint.html)