### PR TITLE
Fail fast when misconfigured 🧨

### DIFF
--- a/documentation/tutorials/auth0-quickstart.md
+++ b/documentation/tutorials/auth0-quickstart.md
@@ -78,8 +78,9 @@ defmodule MyApp.Secrets do
 
   defp get_config(key) do
     :my_app
-    |> Application.get_env(:auth0, [])
-    |> Keyword.fetch(key)
+    |> Application.fetch_env!(:auth0)
+    |> Keyword.fetch!(key)
+    |> then(&{:ok, &1})
   end
 end
 ```


### PR DESCRIPTION
When I first followed the guide, I copy/pasted the code the read the `:redirect_uri` key, but when I typed into my config file, I typed `:redirect_url`.

The failure was completely silent with no error raised.

This change will cause the app to fail loud and clear with  the following error:

```elixir
 (KeyError) key :redirect_uri not found in: [
  client_id: "the-client-id",
  redirect_url: "http://localhost:4000/auth",
  client_secret: "the-client-secret",
  site: "the-site"
]
```