### PR TITLE
Fix missing piece of module path in doc example

### DIFF
--- a/lib/ash_authentication/strategies/oauth2.ex
+++ b/lib/ash_authentication/strategies/oauth2.ex
@@ -187,7 +187,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
           user_info = Ash.Changeset.get_argument(changeset, :user_info)
 
           changeset
-          |> Changeset.change_attribute(:email, user_info["email"])
+          |> Ash.Changeset.change_attribute(:email, user_info["email"])
         end
       end
     end


### PR DESCRIPTION
I think this is a mistake. I didn't cast about for more instances of it.