### PR TITLE
Change redirect_uri secret to be more flexible

### DIFF
--- a/documentation/dsls/DSL:-AshAuthentication.Strategy.OAuth2.cheatmd
+++ b/documentation/dsls/DSL:-AshAuthentication.Strategy.OAuth2.cheatmd
@@ -325,8 +325,8 @@ OAuth2 authentication
   information.
 
 * `:redirect_uri` - Required. The callback URI base.  
-  Not the whole URI back to the callback endpoint, but the URI to your
-  `AuthPlug`.  We can generate the rest.  
+  Either the whole URI back to the callback endpoint or the URI to your
+  `AuthPlug`.
   Whilst not particularly secret, it seemed prudent to allow this to be
   configured dynamically so that you can use different URIs for
   different environments.  

--- a/documentation/dsls/DSL:-AshAuthentication.Strategy.Oidc.cheatmd
+++ b/documentation/dsls/DSL:-AshAuthentication.Strategy.Oidc.cheatmd
@@ -152,8 +152,8 @@ all the same configuration options should you need them.
   information.
 
 * `:redirect_uri` - Required. The callback URI base.  
-  Not the whole URI back to the callback endpoint, but the URI to your
-  `AuthPlug`.  We can generate the rest.  
+  Either the whole URI back to the callback endpoint or the URI to your
+  `AuthPlug`.
   Whilst not particularly secret, it seemed prudent to allow this to be
   configured dynamically so that you can use different URIs for
   different environments.  

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -173,8 +173,14 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
     with {:ok, subject_name} <- Info.authentication_subject_name(strategy.resource),
          {:ok, redirect_uri} <- fetch_secret(strategy, :redirect_uri),
          {:ok, uri} <- URI.new(redirect_uri) do
+      suffix = Path.join([to_string(subject_name), to_string(strategy.name), "callback"])
+      # Don't append the path if the secret ends with the path already
       path =
-        Path.join([uri.path || "/", to_string(subject_name), to_string(strategy.name), "callback"])
+        if String.ends_with?(uri.path, suffix) do
+          uri.path
+        else
+          Path.join([uri.path || "/", suffix])
+        end
 
       {:ok, to_string(%URI{uri | path: path})}
     else


### PR DESCRIPTION
Applies to both OAuth2 and OpenID Connect.

With this the developer can provide either the full URL or the URL up to the AuthPlug path. If the suffix is already there we won't add it again.

Should make it easier to get it on the first try.