### PR TITLE
Add id as an option for sourcing uid for UserIdentity

### DIFF
--- a/lib/ash_authentication/user_identity/upsert_identity_change.ex
+++ b/lib/ash_authentication/user_identity/upsert_identity_change.ex
@@ -31,7 +31,10 @@ defmodule AshAuthentication.UserIdentity.UpsertIdentityChange do
 
     uid =
       user_info
-      |> Map.take(["uid", "sub"])
+      # uid is a convention
+      # sub is supposedly from the spec
+      # id is from what has been seen from Google
+      |> Map.take(["uid", "sub", "id"])
       |> Map.values()
       |> Enum.reject(&is_nil/1)
       |> List.first()


### PR DESCRIPTION
Not sure if this is a fix that is wanted. But I had Google OAuth fail any time I switched the identity_resource thing on in the strategy.