### PR TITLE
better Plug.Router example

### DIFF
--- a/lib/ash_authentication/plug/helpers.ex
+++ b/lib/ash_authentication/plug/helpers.ex
@@ -221,8 +221,12 @@ defmodule AshAuthentication.Plug.Helpers do
     use Plug.Router
     import MyApp.AuthPlug
 
+    plug :match
+
     plug :retrieve_from_bearer
     plug :set_actor, :user
+
+    plug :dispatch
 
     forward "/gql",
       to: Absinthe.Plug,


### PR DESCRIPTION
I'm pretty sure `plug :match` and `plug :dispatch` are required when using `Plug.Router`