### PR TITLE
docs: Mark the `hashed_password` field as private so it does not appear in any API responses

### DIFF
--- a/documentation/tutorials/getting-started-with-authentication.md
+++ b/documentation/tutorials/getting-started-with-authentication.md
@@ -174,7 +174,7 @@ defmodule MyApp.Accounts.User do
   attributes do
     uuid_primary_key :id
     attribute :email, :ci_string, allow_nil?: false
-    attribute :hashed_password, :string, allow_nil?: false, sensitive?: true
+    attribute :hashed_password, :string, allow_nil?: false, sensitive?: true, private?: true
   end
 
   authentication do


### PR DESCRIPTION
As the API extensions grab all public attributes by default - this is one that really should not be included!