### PR TITLE
improvement: infer `api` from a resource

### DIFF
--- a/documentation/dsls/DSL:-AshAuthentication.TokenResource.md
+++ b/documentation/dsls/DSL:-AshAuthentication.TokenResource.md
@@ -70,7 +70,7 @@ Configuration options for this token resource
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`api`](#token-api){: #token-api .spark-required} | `module` |  | The Ash API to use to access this resource. |
+| [`api`](#token-api){: #token-api } | `module` |  | The Ash API to use to access this resource. |
 | [`expunge_expired_action_name`](#token-expunge_expired_action_name){: #token-expunge_expired_action_name } | `atom` | `:expunge_expired` | The name of the action used to remove expired tokens. |
 | [`read_expired_action_name`](#token-read_expired_action_name){: #token-read_expired_action_name } | `atom` | `:read_expired` | The name of the action use to find all expired tokens. |
 | [`expunge_interval`](#token-expunge_interval){: #token-expunge_interval } | `pos_integer` | `12` | How often to scan this resource for records which have expired, and thus can be removed. |

--- a/documentation/dsls/DSL:-AshAuthentication.UserIdentity.md
+++ b/documentation/dsls/DSL:-AshAuthentication.UserIdentity.md
@@ -59,8 +59,8 @@ Configure identity options for this resource
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`api`](#user_identity-api){: #user_identity-api .spark-required} | `module` |  | The Ash API to use to access this resource. |
 | [`user_resource`](#user_identity-user_resource){: #user_identity-user_resource .spark-required} | `module` |  | The user resource to which these identities belong. |
+| [`api`](#user_identity-api){: #user_identity-api } | `module` |  | The Ash API to use to access this resource. |
 | [`uid_attribute_name`](#user_identity-uid_attribute_name){: #user_identity-uid_attribute_name } | `atom` | `:uid` | The name of the `uid` attribute on this resource. |
 | [`strategy_attribute_name`](#user_identity-strategy_attribute_name){: #user_identity-strategy_attribute_name } | `atom` | `:strategy` | The name of the `strategy` attribute on this resource. |
 | [`user_id_attribute_name`](#user_identity-user_id_attribute_name){: #user_identity-user_id_attribute_name } | `atom` | `:user_id` | The name of the `user_id` attribute on this resource. |

--- a/documentation/dsls/DSL:-AshAuthentication.md
+++ b/documentation/dsls/DSL:-AshAuthentication.md
@@ -100,8 +100,8 @@ Configure authentication for this resource
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`api`](#authentication-api){: #authentication-api .spark-required} | `module` |  | The name of the Ash API to use to access this resource when doing anything authenticaiton related. |
 | [`subject_name`](#authentication-subject_name){: #authentication-subject_name } | `atom` |  | The subject name is used anywhere that a short version of your resource name is needed.  Must be unique system-wide and will be inferred from the resource name by default (ie `MyApp.Accounts.User` -> `user`). |
+| [`api`](#authentication-api){: #authentication-api } | `module` |  | The name of the Ash API to use to access this resource when doing anything authenticaiton related. |
 | [`get_by_subject_action_name`](#authentication-get_by_subject_action_name){: #authentication-get_by_subject_action_name } | `atom` | `:get_by_subject` | The name of the read action used to retrieve records. If the action doesn't exist, one will be generated for you. |
 | [`select_for_senders`](#authentication-select_for_senders){: #authentication-select_for_senders } | `list(atom)` |  | A list of fields that we will ensure are selected whenever a sender will be invoked.  Defaults to `[:email]` if there is an `:email` attribute on the resource, and `[]` otherwise. |
 

--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -51,8 +51,7 @@ defmodule AshAuthentication.Dsl do
           api: [
             type: {:behaviour, Api},
             doc:
-              "The name of the Ash API to use to access this resource when doing anything authenticaiton related.",
-            required: true
+              "The name of the Ash API to use to access this resource when doing anything authenticaiton related."
           ],
           get_by_subject_action_name: [
             type: :atom,

--- a/lib/ash_authentication/token_resource.ex
+++ b/lib/ash_authentication/token_resource.ex
@@ -11,8 +11,7 @@ defmodule AshAuthentication.TokenResource do
           type: {:behaviour, Ash.Api},
           doc: """
           The Ash API to use to access this resource.
-          """,
-          required: true
+          """
         ],
         expunge_expired_action_name: [
           type: :atom,

--- a/lib/ash_authentication/token_resource/transformer.ex
+++ b/lib/ash_authentication/token_resource/transformer.ex
@@ -34,7 +34,8 @@ defmodule AshAuthentication.TokenResource.Transformer do
   @spec transform(map) ::
           :ok | {:ok, map} | {:error, term} | {:warn, map, String.t() | [String.t()]} | :halt
   def transform(dsl_state) do
-    with {:ok, dsl_state} <-
+    with {:ok, dsl_state} <- maybe_set_api(dsl_state, :token),
+         {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, :jti, :string,
              primary_key?: true,
              allow_nil?: false,

--- a/lib/ash_authentication/transformer.ex
+++ b/lib/ash_authentication/transformer.ex
@@ -30,7 +30,8 @@ defmodule AshAuthentication.Transformer do
   @spec transform(map) ::
           :ok | {:ok, map} | {:error, term} | {:warn, map, String.t() | [String.t()]} | :halt
   def transform(dsl_state) do
-    with :ok <- validate_at_least_one_strategy(dsl_state),
+    with {:ok, dsl_state} <- maybe_set_api(dsl_state, :authentication),
+         :ok <- validate_at_least_one_strategy(dsl_state),
          :ok <- validate_unique_strategy_names(dsl_state),
          :ok <- validate_unique_add_on_names(dsl_state),
          {:ok, dsl_state} <- maybe_transform_token_lifetime(dsl_state),

--- a/lib/ash_authentication/user_identity.ex
+++ b/lib/ash_authentication/user_identity.ex
@@ -7,8 +7,7 @@ defmodule AshAuthentication.UserIdentity do
       schema: [
         api: [
           type: {:behaviour, Ash.Api},
-          doc: "The Ash API to use to access this resource.",
-          required: true
+          doc: "The Ash API to use to access this resource."
         ],
         user_resource: [
           type: {:behaviour, Ash.Resource},

--- a/lib/ash_authentication/user_identity/transformer.ex
+++ b/lib/ash_authentication/user_identity/transformer.ex
@@ -34,7 +34,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
   @spec transform(map) ::
           :ok | {:ok, map} | {:error, term} | {:warn, map, String.t() | [String.t()]} | :halt
   def transform(dsl_state) do
-    with {:ok, resource} <- persisted_option(dsl_state, :module),
+    with {:ok, dsl_state} <- maybe_set_api(dsl_state, :user_identity),
+         {:ok, resource} <- persisted_option(dsl_state, :module),
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, :id, Type.UUID,
              allow_nil?: false,

--- a/lib/ash_authentication/utils.ex
+++ b/lib/ash_authentication/utils.ex
@@ -80,6 +80,19 @@ defmodule AshAuthentication.Utils do
   def maybe_concat(collection, _test, new_elements), do: Enum.concat(collection, new_elements)
 
   @doc """
+  Used within transformers to infer `api` from a resource if the option is not set.
+  """
+  def maybe_set_api(dsl_state, section) do
+    api = Transformer.get_persisted(dsl_state, :api)
+
+    if api && !Transformer.get_option(dsl_state, [section], :api) do
+      {:ok, Transformer.set_option(dsl_state, [section], :api, api)}
+    else
+      {:ok, dsl_state}
+    end
+  end
+
+  @doc """
   Used within transformers to optionally build actions as needed.
   """
   @spec maybe_build_action(Dsl.t(), atom, (map -> map)) :: {:ok, atom | map} | {:error, any}


### PR DESCRIPTION
Infer `api` set by `use Ash.Resource, api: ...` in `authentication`, `token` and `user_identity` sections.

Safe to remove `required: true` from `api` options because those sections verifiers already do verify that `api` is set and valid.