### PR TITLE
docs: fix `ash_domains` config example in `Get Started` section

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -109,7 +109,7 @@ Be sure to add it to the `ash_domains` config in your `config.exs`
 
 ```elixir
 # in config/config.exs
-config :my_app, ash_domains: [..., MyApp.Accounts]
+config :my_app, :ash_domains, [..., MyApp.Accounts]
 ```
 
 Next, let's define our `Token` resource. This resource is needed


### PR DESCRIPTION
I believe the correction in #676 was slightly off the mark. This little fix adjusts the syntax to the correct value (I think).