### PR TITLE
docs: change 'Get Started' guide for Ash 3.0 compatibility

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -15,7 +15,7 @@ Bring in the `ash_authentication` dependency:
 defp deps()
   [
     # ...
-    {:ash_authentication, "~> 3.11"}
+    {:ash_authentication, "~> 4.0"}
   ]
 end
 ```
@@ -126,7 +126,7 @@ defmodule MyApp.Repo do
   use AshPostgres.Repo, otp_app: :my_app
 
   def installed_extensions do
-    ["uuid-ossp", "citext"]
+    ["ash-functions", "uuid-ossp", "citext"]
   end
 end
 ```


### PR DESCRIPTION
Just a couple little changes to fix some issues related to using this tutorial with Ash 3.0.

- Use newer `ash_authentication` version since old version had dependency resolution errors

- Add `ash-functions` to the extensions list
  - Fixes compiler warning when the item is missing