### PR TITLE
docs: add snippet to help enable policy authorizers

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -141,6 +141,8 @@ defmodule MyApp.Accounts.Token do
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,
     extensions: [AshAuthentication.TokenResource],
+    # If using policies, enable the policy authorizer:
+    # authorizers: [Ash.Policy.Authorizer],
     domain: MyApp.Accounts
 
   postgres do


### PR DESCRIPTION
Fixes an issue in the 'Get Started' section where the code example was missing an import, which then made the code break.