### PR TITLE
fix: broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome! Here you will find everything you need to know to get started with and 
 
 ---
 
-[**How-to**](#how-to) guides are **goal-oriented** recipes for accomplishing specific tasks. These are also good to browse to get an idea of how Ash Authentication works and what is possible with it.
+[**How-to**](#how-to) (**WIP**) guides are **goal-oriented** recipes for accomplishing specific tasks. These are also good to browse to get an idea of how Ash Authentication works and what is possible with it.
 
 ---
 
@@ -43,12 +43,13 @@ Welcome! Here you will find everything you need to know to get started with and 
 ---
 
 ## How To
+https://github.com/team-alembic/ash_authentication/blob/main/documentation/tutorials/auth0.md
 
-- [Authenticate with Auth0](documentation/how-to/auth0.md)
-- [Authenticate with GitHub](documentation/how-to/github.md)
-- [Authenticate with Google](documentation/how-to/google.md)
-- [Authenticate with Magic Links](documentation/how-to/magic-links.md)
-- [Confirmation](documentation/how-to/confirmation.md)
+- [Authenticate with Auth0](documentation/tutorials/auth0.md)
+- [Authenticate with GitHub](documentation/tutorials/github.md)
+- [Authenticate with Google](documentation/tutorials/google.md)
+- [Authenticate with Magic Links](documentation/tutorials/magic-links.md)
+- [Confirmation](documentation/tutorials/confirmation.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Welcome! Here you will find everything you need to know to get started with and 
 
 ---
 
-## How To
-https://github.com/team-alembic/ash_authentication/blob/main/documentation/tutorials/auth0.md
+## Tutorials
 
 - [Authenticate with Auth0](documentation/tutorials/auth0.md)
 - [Authenticate with GitHub](documentation/tutorials/github.md)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ Welcome! Here you will find everything you need to know to get started with and 
 
 ---
 
-[**How-to**](#how-to) (**WIP**) guides are **goal-oriented** recipes for accomplishing specific tasks. These are also good to browse to get an idea of how Ash Authentication works and what is possible with it.
-
----
-
 [**Reference**](#reference) documentation is produced automatically from our source code. It comes in the form of module documentation and DSL documentation. This documentation is **information-oriented**. Use the sidebar and the search bar to find relevant reference information.
 
 ## Tutorials


### PR DESCRIPTION
how-to's were moved to tutorials folder. I've updated these in the readme, and changed how-to folder to be WIP because nothing further exists there.