### PR TITLE
Update Google OAuth Tutorial

### DIFF
--- a/documentation/tutorials/google.md
+++ b/documentation/tutorials/google.md
@@ -22,11 +22,10 @@ defmodule MyApp.Accounts.User do
 
   authentication do
     strategies do
-      oauth2 :google do
+      google do
         client_id MyApp.Secrets
         redirect_uri MyApp.Secrets
-        client_secret MyApp.Secrets end
-        base_url MyApp.Secrets
+        client_secret MyApp.Secrets
       end
     end
   end


### PR DESCRIPTION
Small doc PR that reflects what worked for me when setting up google oauth.

The base_url is optional, so I removed it from the tutorial.