### PR TITLE
Do a compile-time check to make sure that the configured `token_resource` is an Ash.Resource

### DIFF
--- a/lib/ash_authentication/jwt.ex
+++ b/lib/ash_authentication/jwt.ex
@@ -54,6 +54,8 @@ defmodule AshAuthentication.Jwt do
   specified in integer positive hours.
   """
 
+  require Logger
+
   alias Ash.Resource
   alias AshAuthentication.{Info, Jwt.Config, TokenResource}
 
@@ -113,7 +115,9 @@ defmodule AshAuthentication.Jwt do
          :ok <- maybe_store_token(token, resource, user, purpose, action_opts) do
       {:ok, token, claims}
     else
-      {:error, _reason} -> :error
+      {:error, reason} ->
+        Logger.error("Failed to generate token for user: #{inspect reason, pretty: true}")
+        :error
     end
   end
 

--- a/lib/ash_authentication/verifier.ex
+++ b/lib/ash_authentication/verifier.ex
@@ -109,11 +109,23 @@ defmodule AshAuthentication.Verifier do
     end
   end
 
+  @spec is_token_resource(any()) :: boolean() | {boolean(), any()}
+  defp is_token_resource(module) when is_atom(module) do
+    with true <- function_exported?(module, :spark_is, 0),
+         Ash.Resource <- module.spark_is() do
+      true
+    else
+      _ ->
+        {false, module}
+    end
+  end
+  defp is_token_resource(_other), do: false
+
   defp validate_token_resource(dsl_state) do
     if_tokens_enabled(dsl_state, fn dsl_state ->
       with {:ok, resource} when is_truthy(resource) <-
              Info.authentication_tokens_token_resource(dsl_state),
-           true <- is_atom(resource) do
+           true <- is_token_resource(resource) do
         :ok
       else
         {:ok, falsy} when is_falsy(falsy) ->
@@ -122,11 +134,11 @@ defmodule AshAuthentication.Verifier do
         {:error, reason} ->
           {:error, reason}
 
-        false ->
+        {false, bad_token_resource} ->
           {:error,
            DslError.exception(
              path: [:authentication, :tokens, :token_resource],
-             message: "is not a valid module name"
+             message: "`#{bad_token_resource |> bad_token_resource_to_string()}` is not a valid token resource module name"
            )}
       end
     end)
@@ -138,5 +150,19 @@ defmodule AshAuthentication.Verifier do
     else
       :ok
     end
+  end
+
+  # I'm sure this has already been done somewhere else in the Sparkiverse,
+  # so maybe this can be removed and replaced by whatever Spark usually uses
+  # when logging module names?
+  defp bad_token_resource_to_string(module) when is_atom(module) do
+    module
+    |> to_string()
+    |> String.split(".")
+    |> tl()
+    |> Enum.join(".")
+  end
+  defp bad_token_resource_to_string(module) when is_binary(module) do
+    module
   end
 end

--- a/test/ash_authentication/user_with_bad_token_test.exs
+++ b/test/ash_authentication/user_with_bad_token_test.exs
@@ -1,0 +1,82 @@
+defmodule AshAuthentication.UserWithBadTokenTest do
+  @moduledoc false
+
+  use DataCase, async: true
+
+  test "cannot compile with bad token_resource configured" do
+    assert_raise Spark.Error.DslError, ~r/`BadToken` is not a valid token resource module name/, fn ->
+      defmodule UserWithBadToken do
+        @moduledoc false
+        use Ash.Resource,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshAuthentication],
+          validate_domain_inclusion?: false,
+          domain: Example
+
+        require Logger
+
+        @type t :: %__MODULE__{
+                id: Ecto.UUID.t(),
+                email: String.t(),
+                hashed_password: String.t(),
+                created_at: DateTime.t(),
+                updated_at: DateTime.t()
+              }
+
+        attributes do
+          uuid_primary_key :id, writable?: true
+          attribute :email, :ci_string, allow_nil?: false, public?: true
+          attribute :hashed_password, :string, allow_nil?: true, sensitive?: true, public?: false
+          create_timestamp :created_at
+          update_timestamp :updated_at
+        end
+
+        authentication do
+          tokens do
+            enabled? true
+            store_all_tokens? true
+            require_token_presence_for_authentication? true
+            token_resource BadToken
+            signing_secret &get_config/2
+          end
+
+          strategies do
+            password do
+              identity_field :email
+
+              resettable do
+                sender fn user, token, _opts ->
+                  Logger.debug(
+                    "Password reset request for user #{user.username}, token #{inspect(token)}"
+                  )
+                end
+              end
+            end
+          end
+        end
+
+        actions do
+          defaults [:create, :read, :update, :destroy]
+        end
+
+        identities do
+          identity :email, [:email], eager_check_with: Example
+        end
+
+        postgres do
+          table "user_with_token_required"
+          repo(Example.Repo)
+        end
+
+        def get_config(path, _resource) do
+          value =
+            :ash_authentication
+            |> Application.get_all_env()
+            |> get_in(path)
+
+          {:ok, value}
+        end
+      end
+    end
+  end
+end

--- a/test/ash_authentication/user_with_bad_token_test.exs
+++ b/test/ash_authentication/user_with_bad_token_test.exs
@@ -13,16 +13,6 @@ defmodule AshAuthentication.UserWithBadTokenTest do
           validate_domain_inclusion?: false,
           domain: Example
 
-        require Logger
-
-        @type t :: %__MODULE__{
-                id: Ecto.UUID.t(),
-                email: String.t(),
-                hashed_password: String.t(),
-                created_at: DateTime.t(),
-                updated_at: DateTime.t()
-              }
-
         attributes do
           uuid_primary_key :id, writable?: true
           attribute :email, :ci_string, allow_nil?: false, public?: true
@@ -34,10 +24,8 @@ defmodule AshAuthentication.UserWithBadTokenTest do
         authentication do
           tokens do
             enabled? true
-            store_all_tokens? true
-            require_token_presence_for_authentication? true
             token_resource BadToken
-            signing_secret &get_config/2
+            signing_secret fn _, _ -> :dummy end
           end
 
           strategies do
@@ -45,11 +33,7 @@ defmodule AshAuthentication.UserWithBadTokenTest do
               identity_field :email
 
               resettable do
-                sender fn user, token, _opts ->
-                  Logger.debug(
-                    "Password reset request for user #{user.username}, token #{inspect(token)}"
-                  )
-                end
+                sender fn _user, _token, _opts -> :noop end
               end
             end
           end
@@ -64,17 +48,8 @@ defmodule AshAuthentication.UserWithBadTokenTest do
         end
 
         postgres do
-          table "user_with_token_required"
-          repo(Example.Repo)
-        end
-
-        def get_config(path, _resource) do
-          value =
-            :ash_authentication
-            |> Application.get_all_env()
-            |> get_in(path)
-
-          {:ok, value}
+          table "user_with_bad_token_required"
+          repo Example.Repo
         end
       end
     end


### PR DESCRIPTION
## Issue
During a refactor of the auth resources, the `tokens.token_resource` field was not updated properly on my user resource, and so I ended up getting a very vague `:error` result when trying to create tokens, without any other context. It was caused by the module not existing, but the current checks only check that the value configured is an atom.


## Errors

Initial error when trying to log in:
```elixir
[error] | file=gen_server.erl line=2474 mfa=:gen_server.error_info/8 [22:44:23.824]: GenServer #PID<0.1271.0> terminating
** (MatchError) no match of right hand side value: :error
    (ash_authentication 4.0.1) lib/ash_authentication/strategies/password/sign_in_preparation.ex:117: AshAuthentication.Strategy.Password.SignInPreparation.generate_token/3
    (ash_authentication 4.0.1) lib/ash_authentication/strategies/password/sign_in_preparation.ex:44: anonymous fn/3 in AshAuthentication.Strategy.Password.SignInPreparation.prepare/3
    (ash 3.2.4) lib/ash/actions/read/read.ex:2097: anonymous fn/2 in Ash.Actions.Read.run_after_action/2
    (elixir 1.17.2) lib/enum.ex:4858: Enumerable.List.reduce/3
    (elixir 1.17.2) lib/enum.ex:2585: Enum.reduce_while/3
    ...
```

After adding some logging, I got this error:
```elixir
[error] | file=lib/ash_authentication/jwt.ex line=119 mfa=AshAuthentication.Jwt.token_for_user/3 [23:26:09.713]: Failed to generate token for user: "Module `Lpe.Resources.Token` is not an Ash resource"
```

## Improvement

Improved compile-time validation of the token_resource option of the tokens DSL by checking that the passed value is an `Ash.Resource`.

## Further improvements?

Could this be improved to test it being an `AshAuthentication.TokenResource` directly?