### PR TITLE
improvement: enable custom `http_adapters`

### DIFF
--- a/lib/ash_authentication.ex
+++ b/lib/ash_authentication.ex
@@ -67,6 +67,18 @@ defmodule AshAuthentication do
   3. `AshAuthentication.Strategy.MagicLink`
      - authenticate by sending a single-use link to the user.
 
+  ### HTTP client settings
+
+  Most of the authentication strategies based on `OAuth2` wrap the [`assent`](https://hex.pm/packages/assent) package.
+
+  If you needs to customize the behavior of the http client used by `assent`, define a custom `http_adapter` in the 
+  application settings:
+
+  `config :ash_authentication, :http_adapter, {Assent.HTTPAdapter.Finch, supervisor: MyApp.CustomFinch}`
+
+  See [`assent's documentation`](https://hexdocs.pm/assent/README.html#http-client) for more details on the supported 
+  http clients and their configuration.
+
   ## Add-ons
 
   Add-ons are like strategies, except that they don't actually provide

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -82,13 +82,13 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
     config =
       strategy
       |> Map.take(@raw_config_attrs)
-      |> Map.put(:http_adapter, {Finch, supervisor: AshAuthentication.Finch})
 
     with {:ok, config} <- add_secret_value(config, strategy, :base_url),
          {:ok, config} <- add_secret_value(config, strategy, :authorize_url, !!strategy.base_url),
          {:ok, config} <- add_secret_value(config, strategy, :client_id, !!strategy.base_url),
          {:ok, config} <- add_secret_value(config, strategy, :client_secret, !!strategy.base_url),
          {:ok, config} <- add_secret_value(config, strategy, :token_url, !!strategy.base_url),
+         {:ok, config} <- add_http_adapter(config),
          {:ok, config} <-
            add_secret_value(
              config,
@@ -199,5 +199,15 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp add_http_adapter(config) do
+    http_adapter = Application.get_env(
+      :ash_authentication, 
+      :http_adapter, 
+      {Finch, supervisor: AshAuthentication.Finch}
+    )
+
+    {:ok, Map.put(config, :http_adapter, http_adapter)}
   end
 end


### PR DESCRIPTION
Allow users to customize the behavior of the http client used by the oauth-based strategies by configuring a http adapter.