### PR TITLE
chore: add `false` filter on nil identity_field

### DIFF
--- a/lib/ash_authentication/strategies/password/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/password/sign_in_preparation.ex
@@ -25,8 +25,15 @@ defmodule AshAuthentication.Strategy.Password.SignInPreparation do
     identity_field = strategy.identity_field
     identity = Query.get_argument(query, identity_field)
 
+    query =
+      if is_nil(identity) do
+        # This will fail due to the argument being `nil`, so this is just a formality
+        Query.filter(query, false)
+      else
+        Query.filter(query, ^ref(identity_field) == ^identity)
+      end
+
     query
-    |> Query.filter(^ref(identity_field) == ^identity)
     |> check_sign_in_token_configuration(strategy)
     |> Query.before_action(fn query ->
       Ash.Query.ensure_selected(query, [strategy.hashed_password_field])


### PR DESCRIPTION
We never would have actually run the query due to the argument being `nil`, but this avoids an unnecessary warning.