### PR TITLE
fix: add back in accidentally removed debug errors code

### DIFF
--- a/lib/ash_authentication/errors/authentication_failed.ex
+++ b/lib/ash_authentication/errors/authentication_failed.ex
@@ -2,8 +2,6 @@ defmodule AshAuthentication.Errors.AuthenticationFailed do
   @moduledoc """
   A generic, authentication failed error.
   """
-  use Ash.Error.Exception
-
   use Splode.Error,
     fields: [
       caused_by: %{},
@@ -14,14 +12,17 @@ defmodule AshAuthentication.Errors.AuthenticationFailed do
     ],
     class: :forbidden
 
+  alias AshAuthentication.Debug
+
   @type t :: Exception.t()
 
-  def message(_), do: "Authentication failed"
-
-  defimpl Ash.ErrorKind do
-    @moduledoc false
-    def id(_), do: Ecto.UUID.generate()
-    def code(_), do: "authentication_failed"
-    def message(_), do: "Authentication failed"
+  @impl true
+  def exception(args) do
+    args
+    |> super()
+    |> Debug.describe()
   end
+
+  @impl true
+  def message(_), do: "Authentication failed"
 end

--- a/lib/ash_authentication/errors/invalid_token.ex
+++ b/lib/ash_authentication/errors/invalid_token.ex
@@ -2,16 +2,7 @@ defmodule AshAuthentication.Errors.InvalidToken do
   @moduledoc """
   An invalid token was presented.
   """
-  use Ash.Error.Exception
   use Splode.Error, fields: [:type], class: :forbidden
 
   def message(%{type: type}), do: "Invalid #{type} token"
-
-  defimpl Ash.ErrorKind do
-    @moduledoc false
-    def id(_), do: Ecto.UUID.generate()
-    def code(_), do: "invalid_token"
-    def message(%{type: nil}), do: "Invalid token"
-    def message(%{type: type}), do: "Invalid #{type} token"
-  end
 end

--- a/lib/ash_authentication/errors/missing_secret.ex
+++ b/lib/ash_authentication/errors/missing_secret.ex
@@ -2,20 +2,9 @@ defmodule AshAuthentication.Errors.MissingSecret do
   @moduledoc """
   A secret is now missing.
   """
-  use Ash.Error.Exception
   use Splode.Error, fields: [:resource], class: :forbidden
 
   def message(%{path: path, resource: resource}) do
     "Secret for `#{Enum.join(path, ".")}` on the `#{inspect(resource)}` resource is not accessible."
-  end
-
-  defimpl Ash.ErrorKind do
-    @moduledoc false
-    def id(_), do: Ecto.UUID.generate()
-    def code(_), do: "missing_secret"
-
-    def message(%{path: path, resource: resource}),
-      do:
-        "Secret for `#{Enum.join(path, ".")}` on the `#{inspect(resource)}` resource is not accessible."
   end
 end


### PR DESCRIPTION
this also cleans up references to `Ash.ErrorKind` which is dead code in 3.x