### PR TITLE
fix: actually use 'trusted_audiences' in oauth2 strategy

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,7 +34,8 @@ config :ash_authentication,
         base_url: System.get_env("OAUTH2_SITE"),
         authorize_url: "#{System.get_env("OAUTH2_SITE")}/authorize",
         token_url: "#{System.get_env("OAUTH2_SITE")}/oauth/token",
-        user_url: "#{System.get_env("OAUTH2_SITE")}/userinfo"
+        user_url: "#{System.get_env("OAUTH2_SITE")}/userinfo",
+        trusted_audiences: ["01234", "56789"]
       ],
       auth0: [
         client_id: System.get_env("OAUTH2_CLIENT_ID"),
@@ -53,7 +54,8 @@ config :ash_authentication,
         client_secret: System.get_env("OAUTH2_CLIENT_SECRET"),
         redirect_uri: "http://localhost:4000/auth",
         base_url: System.get_env("OAUTH2_SITE"),
-        token_url: "#{System.get_env("OAUTH2_SITE")}/oauth/token"
+        token_url: "#{System.get_env("OAUTH2_SITE")}/oauth/token",
+        trusted_audiences: ["01234", "56789"]
       ]
     ],
     tokens: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,7 +24,8 @@ config :ash_authentication,
         base_url: "https://example.com/",
         authorize_url: "https://example.com/authorize",
         token_url: "https://example.com/oauth/token",
-        user_url: "https://example.com/userinfo"
+        user_url: "https://example.com/userinfo",
+        trusted_audiences: ["01234", "56789"]
       ]
     ],
     tokens: [

--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -26,6 +26,18 @@ defmodule AshAuthentication.Dsl do
        ]}
 
   @doc false
+  @spec secret_list_type :: any
+  def secret_list_type,
+    do:
+      {:or,
+       [
+         {:spark_function_behaviour, AshAuthentication.Secret,
+          {AshAuthentication.SecretFunction, 2}},
+         {:list, :any},
+         nil
+       ]}
+
+  @doc false
   @spec secret_doc :: String.t()
   def secret_doc,
     do:

--- a/lib/ash_authentication/strategies/oauth2.ex
+++ b/lib/ash_authentication/strategies/oauth2.ex
@@ -253,6 +253,8 @@ defmodule AshAuthentication.Strategy.OAuth2 do
 
   @type secret :: nil | String.t() | {module, keyword}
 
+  @type secret_list :: nil | [any()] | {module, keyword}
+
   @type t :: %OAuth2{
           assent_strategy: module,
           auth_method:
@@ -287,7 +289,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
           site: secret,
           strategy_module: module,
           token_url: secret,
-          trusted_audiences: nil | [binary],
+          trusted_audiences: secret_list,
           user_url: secret
         }
 

--- a/lib/ash_authentication/strategies/oauth2/dsl.ex
+++ b/lib/ash_authentication/strategies/oauth2/dsl.ex
@@ -10,6 +10,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Dsl do
   @spec dsl :: Custom.entity()
   def dsl do
     secret_type = AshAuthentication.Dsl.secret_type()
+    secret_list_type = AshAuthentication.Dsl.secret_list_type()
     secret_doc = AshAuthentication.Dsl.secret_doc()
 
     %Entity{
@@ -84,6 +85,14 @@ defmodule AshAuthentication.Strategy.OAuth2.Dsl do
           doc:
             "The API url to access the token endpoint, relative to `site`, e.g `token_url fn _, _ -> {:ok, \"https://example.com/oauth_token\"} end`. #{secret_doc}",
           required: true
+        ],
+        trusted_audiences: [
+          type: secret_list_type,
+          doc: """
+          A list of audiences which are trusted. #{secret_doc}
+          """,
+          required: false,
+          default: nil
         ],
         user_url: [
           type: secret_type,

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -88,6 +88,8 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
          {:ok, config} <- add_secret_value(config, strategy, :client_id, !!strategy.base_url),
          {:ok, config} <- add_secret_value(config, strategy, :client_secret, !!strategy.base_url),
          {:ok, config} <- add_secret_value(config, strategy, :token_url, !!strategy.base_url),
+         {:ok, config} <-
+           add_secret_value(config, strategy, :trusted_audiences, true),
          {:ok, config} <- add_http_adapter(config),
          {:ok, config} <-
            add_secret_value(
@@ -153,6 +155,9 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
 
       {:ok, value} when is_binary(value) and byte_size(value) > 0 ->
         {:ok, Map.put(config, secret_name, value)}
+
+      {:ok, list} when is_list(list) ->
+        {:ok, Map.put(config, secret_name, list)}
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/ash_authentication/strategies/oidc/dsl.ex
+++ b/lib/ash_authentication/strategies/oidc/dsl.ex
@@ -76,14 +76,6 @@ defmodule AshAuthentication.Strategy.Oidc.Dsl do
           "A function for generating the session nonce, `true` to automatically generate it with `AshAuthetnication.Strategy.Oidc.NonceGenerator`, or `false` to disable.",
         default: true,
         required: false
-      ],
-      trusted_audiences: [
-        type: {:or, [nil, {:list, :string}]},
-        doc: """
-        A list of audiences which are trusted.
-        """,
-        default: nil,
-        required: false
       ]
     )
   end

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -197,6 +197,7 @@ defmodule Example.User do
         base_url &get_config/2
         authorize_url &get_config/2
         token_url &get_config/2
+        trusted_audiences &get_config/2
         user_url &get_config/2
         authorization_params scope: "openid profile email"
         auth_method :client_secret_post
@@ -249,6 +250,7 @@ defmodule Example.User do
         client_secret &get_config/2
         redirect_uri &get_config/2
         base_url &get_config/2
+        trusted_audiences &get_config/2
       end
     end
   end


### PR DESCRIPTION
Currently `trusted_audiences` is not usable since it is not passed to Assent as a config value.

This pull request makes `trusted_audiences` a secret so it is configurable at runtime and sets `trusted_audiences` in the assent config.