### PR TITLE
Fix Apple strategy

### DIFF
--- a/lib/ash_authentication/strategies/apple/dsl.ex
+++ b/lib/ash_authentication/strategies/apple/dsl.ex
@@ -57,7 +57,7 @@ defmodule AshAuthentication.Strategy.Apple.Dsl do
     strategy.default_config([])
     |> Enum.map(fn
       {:client_authentication_method, method} ->
-        {:client_authentication_method, String.to_existing_atom(method)}
+        {:client_authentication_method, method}
 
       {:openid_configuration, config} ->
         {:openid_configuration, atomize_keys(config)}


### PR DESCRIPTION
Since the changes in #800 The OIDC strategy takes strings instead of atoms for the `client_authentication_method`.
The Apple dsl was still casting this option to an atom, which prevented compilation with an error.

Removed the casting from atom to string and everything compiles again :)