### PR TITLE
fix: Use correct typespec for `AshAuthentication.Sender.send/3` callback

### DIFF
--- a/lib/ash_authentication/sender.ex
+++ b/lib/ash_authentication/sender.ex
@@ -85,10 +85,10 @@ defmodule AshAuthentication.Sender do
   @doc """
   Sending callback.
 
-  This function will be called with the user, the token and any options passed
+  This function will be called with a value representing a user, the token and any options passed
   to the module in the DSL.
   """
-  @callback send(user :: Resource.record(), token :: String.t(), opts :: list) :: :ok
+  @callback send(user :: Resource.record() | String.t(), token :: String.t(), opts :: list) :: :ok
 
   @doc false
   @spec __using__(any) :: Macro.t()


### PR DESCRIPTION
In the Magic Link strategy, the `send` function is called with either a user (if logging in to an existing account) or just an email address (if creating a new account). The typespec should reflect this!