### PR TITLE
Fix identities concatenation to include primary_key in proper format

### DIFF
--- a/lib/ash_authentication/validations/attribute.ex
+++ b/lib/ash_authentication/validations/attribute.ex
@@ -76,8 +76,7 @@ defmodule AshAuthentication.Validations.Attribute do
       |> Info.primary_key()
       |> MapSet.new()
 
-    identities
-    |> Enum.concat(primary_key)
+    [primary_key | identities]
     |> Enum.find(&MapSet.equal?(&1, fields))
     |> case do
       nil ->


### PR DESCRIPTION
This PR addresses an issue where identities concatenated with primary_key does not preserve the correct nested structure. Specifically, when:

* primary_key is [:id]
* identities is [[:org, :staff_number], [:ssn], [:email]]

The resulting value becomes [[:org, :staff_number], [:ssn], [:email], :id], but it should be [[:org, :staff_number], [:ssn], [:email], [:id]].

This fix ensures that primary_key is correctly wrapped in a list when concatenated, resulting in the expected structure.