### PR TITLE
Allow Custom Attribute Name for `created_at`

### DIFF
--- a/lib/ash_authentication/token_resource.ex
+++ b/lib/ash_authentication/token_resource.ex
@@ -14,6 +14,11 @@ defmodule AshAuthentication.TokenResource do
           The Ash domain to use to access this resource.
           """
         ],
+        created_at_attribute_name: [
+          type: :atom,
+          doc: "The name of the `created_at` attribute on this resource.",
+          default: :created_at
+        ],
         expunge_expired_action_name: [
           type: :atom,
           doc: """

--- a/lib/ash_authentication/token_resource/transformer.ex
+++ b/lib/ash_authentication/token_resource/transformer.ex
@@ -45,6 +45,8 @@ defmodule AshAuthentication.TokenResource.Transformer do
              public?: true
            ),
          :ok <- validate_jti_field(dsl_state),
+         {:ok, created_at} <-
+           TokenResource.Info.token_created_at_attribute_name(dsl_state),
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, :subject, :string, allow_nil?: false, writable?: true),
          :ok <- validate_subject_field(dsl_state),
@@ -68,7 +70,10 @@ defmodule AshAuthentication.TokenResource.Transformer do
              public?: true
            ),
          {:ok, dsl_state} <-
-           maybe_build_attribute(dsl_state, :created_at, :utc_datetime_usec,
+           maybe_build_attribute(
+             dsl_state,
+             created_at,
+             :utc_datetime_usec,
              allow_nil?: false,
              public?: false,
              default: &DateTime.utc_now/0


### PR DESCRIPTION
By default, Phoenix uses `inserted_at` for the column name in `timestamps()`. This allows the customization of the `created_at` attribute name to align with Phoenix defaults.