### PR TITLE
fix: fixed `:sign_in_with_token` that was logging in user automatically even if confirmation is required and account is not confirmed

### DIFF
--- a/lib/ash_authentication/strategies/password/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/password/sign_in_preparation.ex
@@ -76,11 +76,7 @@ defmodule AshAuthentication.Strategy.Password.SignInPreparation do
     end)
   end
 
-  require Logger
-
   defp check_password_and_confirmation(strategy, password, record, query) do
-    Logger.critical("Check password and confirm")
-
     if strategy.hash_provider.valid?(
          password,
          Map.get(record, strategy.hashed_password_field)

--- a/lib/ash_authentication/strategies/password/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/password/sign_in_preparation.ex
@@ -76,7 +76,11 @@ defmodule AshAuthentication.Strategy.Password.SignInPreparation do
     end)
   end
 
+  require Logger
+
   defp check_password_and_confirmation(strategy, password, record, query) do
+    Logger.critical("Check password and confirm")
+
     if strategy.hash_provider.valid?(
          password,
          Map.get(record, strategy.hashed_password_field)

--- a/test/ash_authentication/strategies/password/actions_test.exs
+++ b/test/ash_authentication/strategies/password/actions_test.exs
@@ -71,6 +71,23 @@ defmodule AshAuthentication.Strategy.Password.ActionsTest do
       assert {:ok, _user} =
                Actions.sign_in_with_token(strategy, %{"token" => user.__metadata__.token}, [])
     end
+
+    test "it cannot sign in a user with a sign-in token confirmation is required and account is not confirmed" do
+      password = password()
+
+      user =
+        build_user(password: password, password_confirmation: password)
+
+      {:ok, strategy} = Info.strategy(Example.User, :password)
+      strategy = %{strategy | require_confirmed_with: :confirmed_at}
+
+      {:error, %AuthenticationFailed{caused_by: %AshAuthentication.Errors.UnconfirmedUser{}}} =
+        Actions.sign_in(
+          strategy,
+          %{"username" => user.username, "password" => user.__metadata__.password},
+          context: %{token_type: :sign_in}
+        )
+    end
   end
 
   describe "register/2" do


### PR DESCRIPTION
The actual `:sign_in_with_token` implementation is not taking into account if the account confirmation is required and automatically logs in the user.