### PR TITLE
Fixed a link in the docs and pinned `Assent` to `0.2`

### DIFF
--- a/documentation/tutorials/confirmation.md
+++ b/documentation/tutorials/confirmation.md
@@ -185,7 +185,7 @@ Provided you have your authentication routes hooked up either via `AshAuthentica
 
 ## Blocking unconfirmed users from logging in
 
-The above section explains how to confirm an user account. There's a new directive in the [dsl](file://wsl$/UbuntuLatest/home/bruno/dev/ash/ash_authentication/doc/dsl-ashauthentication-strategy-password.html#authentication-strategies-password-require_confirmed_with) which can require the user to be confirmed in order to log in.
+The above section explains how to confirm an user account. There's a new directive in the [dsl](https://hexdocs.pm/ash_authentication/dsl-ashauthentication-strategy-password.html#authentication-strategies-password-require_confirmed_with) which can require the user to be confirmed in order to log in.
 
 So:
 

--- a/mix.exs
+++ b/mix.exs
@@ -192,7 +192,7 @@ defmodule AshAuthentication.MixProject do
     [
       {:ash, ash_version("~> 3.0 and >= 3.4.29")},
       {:igniter, "~> 0.4", optional: true},
-      {:assent, "~> 0.2 and >= 0.2.8"},
+      {:assent, "~> 0.2"},
       {:bcrypt_elixir, "~> 3.0"},
       {:castore, "~> 1.0"},
       {:finch, "~> 0.19"},


### PR DESCRIPTION
Pinned `Assent version` (fixes https://github.com/team-alembic/ash_authentication/issues/883) and removed a wrong link from docs.