### PR TITLE
fix: ensure that the token resource has only `:jti` as a primary key

### DIFF
--- a/lib/ash_authentication/token_resource/transformer.ex
+++ b/lib/ash_authentication/token_resource/transformer.ex
@@ -204,7 +204,7 @@ defmodule AshAuthentication.TokenResource.Transformer do
                    HAVING COUNT(*) > 1
                ),
                revocation_tokens AS (
-                   SELECT t.jti
+                   SELECT DISTINCT ON (t.jti) t.id
                    FROM tokens t
                    JOIN duplicate_tokens d ON t.jti = d.jti
                    WHERE t.purpose = 'revocation' 
@@ -213,10 +213,10 @@ defmodule AshAuthentication.TokenResource.Transformer do
                    SELECT t.*
                    FROM tokens t
                    JOIN duplicate_tokens d ON t.jti = d.jti
-                   WHERE t.jti NOT IN (SELECT jti FROM revocation_tokens)
+                   WHERE t.id NOT IN (SELECT id FROM revocation_tokens)
                )
                DELETE FROM tokens
-               WHERE jti IN (SELECT jti FROM other_tokens);
+               WHERE id IN (SELECT id FROM other_tokens);
                \""")
            """
          )}

--- a/lib/mix/tasks/ash_authentication.install.ex
+++ b/lib/mix/tasks/ash_authentication.install.ex
@@ -286,8 +286,6 @@ if Code.ensure_loaded?(Igniter) do
               "read",
               "--extend",
               extensions,
-              "--uuid-primary-key",
-              "id",
               "--attribute",
               "jti:string:primary_key:public:required:sensitive",
               "--attribute",

--- a/test/mix/tasks/ash_authentication.install_test.exs
+++ b/test/mix/tasks/ash_authentication.install_test.exs
@@ -142,8 +142,6 @@ defmodule Mix.Tasks.AshAuthentication.InstallTest do
       end
 
       attributes do
-        uuid_primary_key(:id)
-
         attribute :jti, :string do
           primary_key?(true)
           public?(true)


### PR DESCRIPTION
for users who have used the generators to create their application, they will see a compile time error explaining how to fix this issue.

![CleanShot 2025-02-12 at 17 22 29@2x](https://github.com/user-attachments/assets/217f0d3c-583a-42a1-bc41-60617b16ad92)

EDIT:

slightly fixed wording:

           You are likely seeing this as a by-product of an error with the generators 
           that added a `uuid_primary_key :id` to the token resource.

