### PR TITLE
Do not enforce confirm_at attribute type

### DIFF
--- a/lib/ash_authentication/add_ons/confirmation/transformer.ex
+++ b/lib/ash_authentication/add_ons/confirmation/transformer.ex
@@ -167,9 +167,8 @@ defmodule AshAuthentication.AddOn.Confirmation.Transformer do
   defp validate_confirmed_at_attribute(dsl_state, strategy) do
     with {:ok, resource} <- persisted_option(dsl_state, :module),
          {:ok, attribute} <- find_attribute(dsl_state, strategy.confirmed_at_field),
-         :ok <- validate_attribute_option(attribute, resource, :writable?, [true]),
-         :ok <- validate_attribute_option(attribute, resource, :allow_nil?, [true]) do
-      validate_attribute_option(attribute, resource, :type, [Type.UtcDatetimeUsec])
+         :ok <- validate_attribute_option(attribute, resource, :writable?, [true]) do
+      validate_attribute_option(attribute, resource, :allow_nil?, [true])
     end
   end
 

--- a/lib/mix/tasks/ash_authentication.install.ex
+++ b/lib/mix/tasks/ash_authentication.install.ex
@@ -315,7 +315,7 @@ if Code.ensure_loaded?(Igniter) do
           |> Ash.Resource.Igniter.add_new_attribute(token_resource, :created_at, """
           create_timestamp :created_at
           """)
-          |> Ash.Resource.Igniter.add_new_attribute(token_resource, :created_at, """
+          |> Ash.Resource.Igniter.add_new_attribute(token_resource, :updated_at, """
           update_timestamp :updated_at
           """)
           # Consider moving to the extension's `install/5` callback, but we need


### PR DESCRIPTION
The following commit was made to not enforce the type of the `expires_at` field so extended it to `confirm_at`

https://github.com/team-alembic/ash_authentication/commit/a305d462c412546ad3afab829aeaa9cb9d8ad75b#diff-fec59acf8cbd378e0230f6426f1ef645455e4539397bf7c9f659d6a66624f1c8

The reason being that I'm using `AshPostgres.TimestamptzUsec` instead