### PR TITLE
make sure to point to right function for deprecation for AshAuthentication.Secret.secret_for/3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.1
-erlang 27.0
+elixir 1.18.3-otp-27
+erlang 27.3

--- a/lib/ash_authentication/secret.ex
+++ b/lib/ash_authentication/secret.ex
@@ -65,7 +65,7 @@ defmodule AshAuthentication.Secret do
 
   require Logger
 
-  @doc deprecated: "Use Foo.bar/2 instead"
+  @doc deprecated: "Use AshAuthentication.Secret.secret_for/4 instead"
   @callback secret_for(secret_name :: [atom], Resource.t(), keyword) :: {:ok, String.t()} | :error
 
   @doc """


### PR DESCRIPTION
Feel free to dismiss the `tool-versions` update, i just like to use the latest otp and elixir when possible.