### PR TITLE
improvement: Add a patchable empty `authentication.providers` section.

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.md
+++ b/documentation/dsls/DSL-AshAuthentication.md
@@ -110,6 +110,7 @@ Configure authentication for this resource
  * [tokens](#authentication-tokens)
  * [strategies](#authentication-strategies)
  * [add_ons](#authentication-add_ons)
+ * [providers](#authentication-providers)
 
 
 
@@ -159,6 +160,15 @@ Configure authentication strategies on this resource
 
 ### authentication.add_ons
 Additional add-ons related to, but not providing authentication
+
+
+
+
+
+
+
+### authentication.providers
+A DSL section for extensions to add authentication providers
 
 
 

--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -155,6 +155,12 @@ defmodule AshAuthentication.Dsl do
             describe: "Additional add-ons related to, but not providing authentication",
             entities: [],
             patchable?: true
+          },
+          %Section{
+            name: :providers,
+            describe: "A DSL section for extensions to add authentication providers",
+            entities: [],
+            patchable?: true
           }
         ]
       }


### PR DESCRIPTION
This can be used by extensions which provide methods for users of other systems to authenticate using AA as the source of truth.