### PR TITLE
Update bcrypt_provider.ex

### DIFF
--- a/lib/ash_authentication/bcrypt_provider.ex
+++ b/lib/ash_authentication/bcrypt_provider.ex
@@ -28,7 +28,8 @@ defmodule AshAuthentication.BcryptProvider do
 
   """
   @impl true
-  @spec valid?(input :: String.t(), hash :: String.t()) :: boolean
+  @spec valid?(input :: String.t() | nil, hash :: String.t()) :: boolean
+  def valid?(nil, hash), do: false
   def valid?(input, hash) when is_binary(input) and is_binary(hash),
     do: Bcrypt.verify_pass(input, hash)
 


### PR DESCRIPTION
fix: add guard clause when input is nil