### PR TITLE
Update docs on using require_confirmed_with options

### DIFF
--- a/documentation/tutorials/confirmation.md
+++ b/documentation/tutorials/confirmation.md
@@ -202,7 +202,7 @@ authentication do
   strategies do
     strategy :password do
       ...
-      # replace with your confirmation strategy
+      # which confirmation strategy to require confirmation for
       require_confirmed_with :confirm_new_user
     end
   end

--- a/documentation/tutorials/confirmation.md
+++ b/documentation/tutorials/confirmation.md
@@ -191,10 +191,20 @@ The above section explains how to confirm an user account. There's a new directi
 So:
 
 ```
-strategies do
-  strategy :password do
-    ...
-    require_confirmed_with :confirmed_at
+authentication do
+  ...
+  add_ons do
+    confirmation :confirm_new_user do
+      ...
+    end
+  end
+
+  strategies do
+    strategy :password do
+      ...
+      # replace with your confirmation strategy
+      require_confirmed_with :confirm_new_user
+    end
   end
 end
 ```


### PR DESCRIPTION
Hi @zachdaniel,

Thank you for helping me out. Based on previous [discord thread](https://discord.com/channels/711271361523351632/1253437793053577226/1361720542746640618), my intention here is to understand on how to use [`require_confirmed_with`](https://hexdocs.pm/ash_authentication/confirmation.html#blocking-unconfirmed-users-from-logging-in) when blocking unconfirmed users from logging in.

If you allow this PR, which code below is appropriate?

Option A:
```elixir
authentication do
  ...
  add_ons do
    confirmation :confirm_new_user do
      ...
    end
  end

  strategies do
    strategy :password do
      ...
      # replace with your confirmation strategy
      require_confirmed_with :confirm_new_user
    end
  end
end
```

Option B:
```elixir
strategies do
  strategy :password do
    ...
    # replace with your confirmation strategy
    require_confirmed_with :confirmed_at
  end
end
```

