### PR TITLE
fix(MagicLink): Add `require_interaction?` option to magic link strategy.

### DIFF
--- a/dev/dev_server/test_page.ex
+++ b/dev/dev_server/test_page.ex
@@ -23,7 +23,10 @@ defmodule DevServer.TestPage do
     resources =
       :ash_authentication
       |> AshAuthentication.authenticated_resources()
-      |> Enum.map(&{&1, Info.authentication_options(&1), Info.authentication_strategies(&1)})
+      |> Enum.map(
+        &{&1, Info.authentication_options(&1),
+         Info.authentication_strategies(&1) ++ Info.authentication_add_ons(&1)}
+      )
 
     current_users =
       conn.assigns
@@ -182,7 +185,8 @@ defmodule DevServer.TestPage do
   defp render_strategy(strategy, :callback, _) when strategy.provider in [:oauth2, :oidc], do: ""
 
   defp render_strategy(strategy, :sign_in, _options)
-       when is_struct(strategy, Example.OnlyMartiesAtTheParty) do
+       when is_struct(strategy, Example.OnlyMartiesAtTheParty) or
+              is_struct(strategy, ExampleMultiTenant.OnlyMartiesAtTheParty) do
     EEx.eval_string(
       ~s"""
       <form method="<%= @method %>" action="<%= @route %>">
@@ -219,6 +223,27 @@ defmodule DevServer.TestPage do
         strategy: strategy,
         route: route_for_phase(strategy, phase),
         options: options,
+        method: Strategy.method_for_phase(strategy, phase)
+      ]
+    )
+  end
+
+  defp render_strategy(strategy, phase, _options)
+       when is_struct(strategy, Strategy.MagicLink) and phase == :accept do
+    EEx.eval_string(
+      ~s"""
+      <form method="<%= @method %>" action="<%= @route %>">
+      <fieldset>
+        <legend><%= @strategy.name %> accept</legend>
+        <input type="text" name="token" placeholder="token" />
+        <br />
+        <input type="submit" value="Accept" />
+      </fieldset>
+      </form>
+      """,
+      assigns: [
+        strategy: strategy,
+        route: route_for_phase(strategy, phase),
         method: Strategy.method_for_phase(strategy, phase)
       ]
     )

--- a/documentation/dsls/DSL-AshAuthentication.Strategy.MagicLink.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.MagicLink.md
@@ -79,6 +79,20 @@ Signing in using a magic link token:
     ...> signed_in_user.id == user
     true
 
+## Usage with AshAuthenticationPhoenix
+
+If you are using `AshAuthenticationPhoenix`, and have `require_authentication?` set to `true`, which you very much should, then you will need to add a `magic_sign_in_route` to your router. This is placed in the same location as `auth_routes`, and should be provided the user and the strategy name. For example:
+
+```elixir
+# Remove this if you do not want to use the magic link strategy
+magic_sign_in_route(
+  MyApp.Accounts.User,
+  :sign_in,
+  auth_routes_prefix: "/auth",
+  overrides: [MyApp.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+)
+```
+
 ## Plugs
 
 The magic link strategy provides plug endpoints for both request and sign-in
@@ -129,6 +143,7 @@ Strategy for authenticating using local users with a magic link
 | [`identity_field`](#authentication-strategies-magic_link-identity_field){: #authentication-strategies-magic_link-identity_field } | `atom` | `:username` | The name of the attribute which uniquely identifies the user, usually something like `username` or `email_address`. |
 | [`token_lifetime`](#authentication-strategies-magic_link-token_lifetime){: #authentication-strategies-magic_link-token_lifetime } | `pos_integer \| {pos_integer, :days \| :hours \| :minutes \| :seconds}` | `{10, :minutes}` | How long the sign in token is valid.  If no unit is provided, then `minutes` is assumed. |
 | [`prevent_hijacking?`](#authentication-strategies-magic_link-prevent_hijacking?){: #authentication-strategies-magic_link-prevent_hijacking? } | `boolean` | `true` | Requires a confirmation add_on to be present if the password strategy is used with the same identity_field. |
+| [`require_interaction?`](#authentication-strategies-magic_link-require_interaction?){: #authentication-strategies-magic_link-require_interaction? } | `boolean` | `false` | Whether or not to require user interaction to sign in. If true, the magic link URLs are changed to a `POST` request, and AshAuthenticationPhoenix will show a button to confirm when the page is visited |
 | [`request_action_name`](#authentication-strategies-magic_link-request_action_name){: #authentication-strategies-magic_link-request_action_name } | `atom` |  | The name to use for the request action. Defaults to `request_<strategy_name>` |
 | [`lookup_action_name`](#authentication-strategies-magic_link-lookup_action_name){: #authentication-strategies-magic_link-lookup_action_name } | `atom` |  | The action to use when looking up a user by their identity. Defaults to `get_by_<identity_field>` |
 | [`single_use_token?`](#authentication-strategies-magic_link-single_use_token?){: #authentication-strategies-magic_link-single_use_token? } | `boolean` | `true` | Automatically revoke the token once it's been used for sign in. |

--- a/documentation/tutorials/magic-links.md
+++ b/documentation/tutorials/magic-links.md
@@ -15,6 +15,7 @@ strategies do
   magic_link do
     identity_field :email
     registration_enabled? true
+    require_interaction? true
 
     sender(Example.Accounts.User.Senders.SendMagicLink)
   end
@@ -32,6 +33,12 @@ This allows a user who does not exist to request a magic link and sign up with o
 ### Registration Disabled (default)
 
 When registration is disabled, signing in with magic link is a _read_ action.
+
+### Require Interaction
+
+Some email clients, virus scanners, etc will retrieve a link automatically without user interaction, causing the magic link token to be consumed and thus fail when the user clicks the link.  The mitigate this we now default to requiring that the user click a "sign in" button to ensure that retrieving the confirmation page does not actually consume the token.  By default if a GET request is sent to the magic link endpoint a very simple form is served which submits to the same URL with the same token parameter as a POST.  You probably don't want to serve this page to users in production.  You can work around this by placing your own page at the same path before it in the router, or changing the email link to a different URL.
+
+See also `AshAuthentication.Phoenix.Router.magic_sign_in_route/3`.
 
 ## Create an email sender and email template
 

--- a/lib/ash_authentication/plug/dispatcher.ex
+++ b/lib/ash_authentication/plug/dispatcher.ex
@@ -24,6 +24,7 @@ defmodule AshAuthentication.Plug.Dispatcher do
   @spec call(Conn.t(), config | any) :: Conn.t()
   def call(conn, {phase, strategy, return_to}) do
     activity = {Strategy.name(strategy), phase}
+    conn = %{conn | params: Map.drop(conn.params, ["glob"])}
 
     strategy
     |> Strategy.plug(phase, conn)

--- a/lib/ash_authentication/strategies/magic_link.ex
+++ b/lib/ash_authentication/strategies/magic_link.ex
@@ -78,6 +78,20 @@ defmodule AshAuthentication.Strategy.MagicLink do
       ...> signed_in_user.id == user
       true
 
+  ## Usage with AshAuthenticationPhoenix
+
+  If you are using `AshAuthenticationPhoenix`, and have `require_authentication?` set to `true`, which you very much should, then you will need to add a `magic_sign_in_route` to your router. This is placed in the same location as `auth_routes`, and should be provided the user and the strategy name. For example:
+
+  ```elixir
+  # Remove this if you do not want to use the magic link strategy
+  magic_sign_in_route(
+    MyApp.Accounts.User,
+    :sign_in,
+    auth_routes_prefix: "/auth",
+    overrides: [MyApp.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+  )
+  ```
+
   ## Plugs
 
   The magic link strategy provides plug endpoints for both request and sign-in
@@ -107,14 +121,15 @@ defmodule AshAuthentication.Strategy.MagicLink do
   """
 
   defstruct identity_field: :username,
+            lookup_action_name: nil,
             name: nil,
-            request_action_name: nil,
-            resource: nil,
-            sender: nil,
             prevent_hijacking?: true,
             registration_enabled?: false,
+            request_action_name: nil,
+            require_interaction?: false,
+            resource: nil,
+            sender: nil,
             sign_in_action_name: nil,
-            lookup_action_name: nil,
             single_use_token?: true,
             strategy_module: __MODULE__,
             token_lifetime: {10, :minutes},
@@ -127,15 +142,16 @@ defmodule AshAuthentication.Strategy.MagicLink do
 
   @type t :: %__MODULE__{
           identity_field: atom,
+          lookup_action_name: nil,
           name: atom,
           prevent_hijacking?: boolean,
           registration_enabled?: boolean,
           request_action_name: atom,
+          require_interaction?: boolean,
           resource: module,
           sender: {module, keyword},
-          lookup_action_name: nil,
-          single_use_token?: boolean,
           sign_in_action_name: atom,
+          single_use_token?: boolean,
           strategy_module: module,
           token_lifetime: pos_integer(),
           token_param_name: atom

--- a/lib/ash_authentication/strategies/magic_link/dsl.ex
+++ b/lib/ash_authentication/strategies/magic_link/dsl.ex
@@ -43,6 +43,12 @@ defmodule AshAuthentication.Strategy.MagicLink.Dsl do
           doc:
             "Requires a confirmation add_on to be present if the password strategy is used with the same identity_field."
         ],
+        require_interaction?: [
+          type: :boolean,
+          default: false,
+          doc:
+            "Whether or not to require user interaction to sign in. If true, the magic link URLs are changed to a `POST` request, and AshAuthenticationPhoenix will show a button to confirm when the page is visited"
+        ],
         request_action_name: [
           type: :atom,
           doc: "The name to use for the request action. Defaults to `request_<strategy_name>`",

--- a/lib/ash_authentication/strategies/magic_link/sign_in_form.html.eex
+++ b/lib/ash_authentication/strategies/magic_link/sign_in_form.html.eex
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Sign In with Magic Link</title>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <h1>Sign in</h1>
+
+    <form method="post" action="<%= @conn.request_path %>">
+      <input type="hidden" name="token" value="<%= @token %>" />
+      <input type="submit" value="Sign in" />
+    </form>
+  </body>
+</html>
+

--- a/lib/ash_authentication/strategies/magic_link/transformer.ex
+++ b/lib/ash_authentication/strategies/magic_link/transformer.ex
@@ -9,6 +9,7 @@ defmodule AshAuthentication.Strategy.MagicLink.Transformer do
   import AshAuthentication.Utils
   import AshAuthentication.Validations
   import AshAuthentication.Strategy.Custom.Helpers
+  require Logger
 
   @doc false
   @spec transform(MagicLink.t(), dsl_state) :: {:ok, MagicLink.t() | dsl_state} | {:error, any}
@@ -34,7 +35,8 @@ defmodule AshAuthentication.Strategy.MagicLink.Transformer do
              dsl_state,
              strategy.request_action_name,
              &build_request_action(&1, strategy)
-           ) do
+           ),
+         :ok <- warn_on_require_interaction(strategy) do
       dsl_state =
         dsl_state
         |> then(
@@ -170,5 +172,26 @@ defmodule AshAuthentication.Strategy.MagicLink.Transformer do
       arguments: arguments,
       preparations: preparations
     )
+  end
+
+  defp warn_on_require_interaction(strategy) when strategy.require_interaction?, do: :ok
+
+  defp warn_on_require_interaction(strategy) do
+    bypassing_error? =
+      :ash_authentication
+      |> Application.get_env(:bypass_require_interaction_for_magic_link?, false)
+
+    if bypassing_error? do
+      :ok
+    else
+      Logger.warning(fn ->
+        """
+        `require_interaction?` should be set to true on the #{inspect(strategy.name)} magic link strategy for #{inspect(strategy.resource)}.
+        Without it, magic links use a `GET` endpoint for signing in.  Some email clients and security tools (e.g., Outlook, virus scanners, and email previewers) may automatically follow these links, unintentionally consuming the sign in token making it unavailable to the end user.
+
+        If you would like to keep the old behaviour and remove this warning then you can do so by setting `config :ash_authentication. :bypass_require_interaction_for_magic_link?, true` in your configuration.
+        """
+      end)
+    end
   end
 end

--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -169,6 +169,7 @@ if Code.ensure_loaded?(Igniter) do
       magic_link do
         identity_field :#{options[:identity_field]}
         registration_enabled? true
+        require_interaction? true
 
         sender #{inspect(sender)}
       end
@@ -394,6 +395,13 @@ if Code.ensure_loaded?(Igniter) do
         {igniter, [mailer]} ->
           {_web_module_exists?, use_web_module, igniter} = create_use_web_module(igniter)
 
+          url =
+            if use_web_module do
+              "\#{url(~p\"/magic_link?token=\#{params[:token}\")}"
+            else
+              "/auth/user/magic_link?token=\#{params[:token]}"
+            end
+
           Igniter.Project.Module.create_module(igniter, sender, ~s'''
           @moduledoc """
           Sends a magic link email
@@ -426,11 +434,11 @@ if Code.ensure_loaded?(Igniter) do
           end
 
           defp body(params) do
-            url = url(~p"/auth/user/magic_link/?token=\#{params[:token]}")
+            # NOTE: You may have to change this to match your magic link acceptance URL.
 
             """
             <p>Hello, \#{params[:email]}! Click this link to sign in:</p>
-            <p><a href="\#{url}">\#{url}</a></p>
+            <p><a href="\#{url}">#{url}</a></p>
             """
           end
           ''')
@@ -458,7 +466,7 @@ if Code.ensure_loaded?(Igniter) do
 
       url =
         if use_web_module do
-          "\#{url(~p\"/auth/user/magic_link/?token=\#{token}\")}"
+          "\#{url(~p\"/magic_link/?token=\#{token}\")}"
         else
           "/auth/user/magic_link/?token=\#{token}"
         end

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -291,6 +291,24 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
         |      sensitive?(true)
         |    end
       """)
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |   action :request_magic_link do
+      + |     argument :email, :ci_string do
+      + |       allow_nil?(false)
+      + |     end
+      + |
+      + |     run(AshAuthentication.Strategy.MagicLink.Request)
+      + |   end
+      """)
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |     magic_link do
+      + |       identity_field(:email)
+      + |       registration_enabled?(true)
+      + |       require_interaction?(true)
+      + |
+      + |       sender(Test.Accounts.User.Senders.SendMagicLinkEmail)
+      + |     end
+      """)
     end
   end
 end

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -257,6 +257,8 @@ defmodule Example.User do
       end
 
       magic_link do
+        require_interaction? true
+
         sender fn user, token, _opts ->
           Logger.debug("Magic link request for #{user.username}, token #{inspect(token)}")
         end

--- a/test/support/example/user_with_register_magic_link.ex
+++ b/test/support/example/user_with_register_magic_link.ex
@@ -35,6 +35,7 @@ defmodule Example.UserWithRegisterMagicLink do
       magic_link do
         identity_field :email
         registration_enabled? true
+        require_interaction? true
 
         sender fn user, token, _opts ->
           email =

--- a/test/support/example_multi_tenant/user.ex
+++ b/test/support/example_multi_tenant/user.ex
@@ -230,6 +230,8 @@ defmodule ExampleMultiTenant.User do
       end
 
       magic_link do
+        require_interaction? true
+
         sender fn user, token, _opts ->
           Logger.debug("Magic link request for #{user.username}, token #{inspect(token)}")
         end

--- a/test/support/example_multi_tenant/user_with_register_magic_link.ex
+++ b/test/support/example_multi_tenant/user_with_register_magic_link.ex
@@ -37,6 +37,7 @@ defmodule ExampleMultiTenant.UserWithRegisterMagicLink do
       magic_link do
         identity_field :email
         registration_enabled? true
+        require_interaction? true
 
         sender fn user, token, _opts ->
           email =


### PR DESCRIPTION
This is to stop magic link tokens being automatically consumed by email clients, virus scanners, etc.