### PR TITLE
improvement(Confirmation): Provide a default accept phase form.

### DIFF
--- a/dev/dev_server/test_page.ex
+++ b/dev/dev_server/test_page.ex
@@ -148,12 +148,12 @@ defmodule DevServer.TestPage do
        do: ""
 
   defp render_strategy(strategy, phase, options)
-       when strategy.provider == :confirmation and phase == :confirm do
+       when strategy.provider == :confirmation and phase == :accept do
     EEx.eval_string(
       ~s"""
       <form method="<%= @method %>" action="<%= @route %>">
         <fieldset>
-          <legend><%= @strategy.name %></legend>
+        <legend><%= @strategy.name %> <%= @phase %></legend>
           <input type="text" name="confirm" placeholder="confirmation token" />
           <br />
           <input type="submit" value="Confirm" />
@@ -163,6 +163,30 @@ defmodule DevServer.TestPage do
       assigns: [
         strategy: strategy,
         route: route_for_phase(strategy, phase),
+        phase: phase,
+        options: options,
+        method: Strategy.method_for_phase(strategy, phase)
+      ]
+    )
+  end
+
+  defp render_strategy(strategy, phase, options)
+       when strategy.provider == :confirmation and phase == :confirm do
+    EEx.eval_string(
+      ~s"""
+      <form method="<%= @method %>" action="<%= @route %>">
+        <fieldset>
+          <legend><%= @strategy.name %> <%= @phase %></legend>
+          <input type="text" name="confirm" placeholder="confirmation token" />
+          <br />
+          <input type="submit" value="Confirm" />
+        </fieldset>
+      </form>
+      """,
+      assigns: [
+        strategy: strategy,
+        route: route_for_phase(strategy, phase),
+        phase: phase,
         options: options,
         method: Strategy.method_for_phase(strategy, phase)
       ]

--- a/lib/ash_authentication/add_ons/confirmation/confirmation_form.html.eex
+++ b/lib/ash_authentication/add_ons/confirmation/confirmation_form.html.eex
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Confirm your account</title>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <h1>Confirm your account</h1>
+
+    <form method="post" action="<%= @conn.request_path %>">
+      <input type="hidden" name="confirm" value="<%= @token %>" />
+      <input type="submit" value="Confirm" />
+    </form>
+  </body>
+</html>
+

--- a/lib/ash_authentication/add_ons/confirmation/strategy.ex
+++ b/lib/ash_authentication/add_ons/confirmation/strategy.ex
@@ -9,7 +9,7 @@ defimpl AshAuthentication.Strategy, for: AshAuthentication.AddOn.Confirmation do
   alias Plug.Conn
 
   @typedoc "The request phases supposed by this strategy"
-  @type phase :: :confirm
+  @type phase :: :accept | :confirm
 
   @typedoc "The actions supported by this strategy"
   @type action :: :confirm
@@ -20,7 +20,8 @@ defimpl AshAuthentication.Strategy, for: AshAuthentication.AddOn.Confirmation do
 
   @doc false
   @spec phases(Confirmation.t()) :: [phase]
-  def phases(_), do: [:confirm]
+  def phases(strategy) when strategy.require_interaction?, do: [:accept, :confirm]
+  def phases(_strategy), do: [:confirm]
 
   @doc false
   @spec actions(Confirmation.t()) :: [action]
@@ -28,7 +29,7 @@ defimpl AshAuthentication.Strategy, for: AshAuthentication.AddOn.Confirmation do
 
   @doc false
   @spec method_for_phase(Confirmation.t(), phase) :: Strategy.http_method()
-  def method_for_phase(strategy, _phase) when strategy.require_interaction?, do: :post
+  def method_for_phase(strategy, :confirm) when strategy.require_interaction?, do: :post
 
   def method_for_phase(_strategy, _phase), do: :get
 
@@ -36,18 +37,19 @@ defimpl AshAuthentication.Strategy, for: AshAuthentication.AddOn.Confirmation do
   @spec routes(Confirmation.t()) :: [Strategy.route()]
   def routes(strategy) do
     subject_name = Info.authentication_subject_name!(strategy.resource)
+    path = "/#{subject_name}/#{strategy.name}"
 
-    path =
-      [subject_name, strategy.name]
-      |> Enum.map(&to_string/1)
-      |> Path.join()
-
-    [{"/#{path}", :confirm}]
+    if strategy.require_interaction? do
+      [{path, :confirm}, {path, :accept}]
+    else
+      [{path, :confirm}]
+    end
   end
 
   @doc false
   @spec plug(Confirmation.t(), phase, Conn.t()) :: Conn.t()
   def plug(strategy, :confirm, conn), do: Confirmation.Plug.confirm(conn, strategy)
+  def plug(strategy, :accept, conn), do: Confirmation.Plug.accept(conn, strategy)
 
   @doc false
   @spec action(Confirmation.t(), action, map, keyword) :: {:ok, Resource.record()} | {:error, any}

--- a/lib/ash_authentication/strategies/magic_link/plug.ex
+++ b/lib/ash_authentication/strategies/magic_link/plug.ex
@@ -10,7 +10,6 @@ defmodule AshAuthentication.Strategy.MagicLink.Plug do
   import Ash.PlugHelpers, only: [get_actor: 1, get_tenant: 1, get_context: 1]
   import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
   require EEx
-  require Logger
 
   @doc """
   Handle a request for a magic link.
@@ -34,7 +33,7 @@ defmodule AshAuthentication.Strategy.MagicLink.Plug do
   end
 
   @doc """
-  Present a sign in button to a user.
+  Present a sign in button to the user.
   """
   @spec accept(Conn.t(), MagicLink.t()) :: Conn.t()
   # sobelow_skip ["XSS.SendResp"]

--- a/test/ash_authentication/add_ons/confirmation/strategy_test.exs
+++ b/test/ash_authentication/add_ons/confirmation/strategy_test.exs
@@ -10,6 +10,7 @@ defmodule AshAuthentication.AddOn.Confirmation.StrategyTest do
   describe "Strategy.phases/1" do
     test "it returns the correct phase" do
       assert [:confirm] = Strategy.phases(%Confirmation{})
+      assert [:accept, :confirm] = Strategy.phases(%Confirmation{require_interaction?: true})
     end
   end
 
@@ -23,11 +24,28 @@ defmodule AshAuthentication.AddOn.Confirmation.StrategyTest do
     test "it returns the correct route" do
       {:ok, strategy} = Info.strategy(Example.User, :confirm)
 
-      assert [{"/user/confirm", :confirm}] = Strategy.routes(strategy)
+      assert [{"/user/confirm", :confirm}] =
+               Strategy.routes(%{strategy | require_interaction?: false})
+
+      assert [{"/user/confirm", :confirm}, {"/user/confirm", :accept}] =
+               Strategy.routes(%{strategy | require_interaction?: true})
     end
   end
 
   describe "Strategy.plug/3" do
+    test "it delegates to `Confirmation.Plug.accept/2` for the accept phase" do
+      conn = conn(:get, "/")
+      strategy = %Confirmation{require_interaction?: true}
+
+      Confirmation.Plug
+      |> expect(:accept, fn rx_conn, rx_strategy ->
+        assert rx_conn == conn
+        assert rx_strategy == strategy
+      end)
+
+      Strategy.plug(strategy, :accept, conn)
+    end
+
     test "it delegates to `Confirmation.Plug.confirm/2` for the confirm phase" do
       conn = conn(:get, "/")
       strategy = %Confirmation{}


### PR DESCRIPTION
When `require_interaction?` is turned on the `GET` for that conirmation route no longer works.  This change adds an accept phase similar to the one provided by the magic link strategy.