### PR TITLE
improvement: pass along the action_input.context to the send_opts.

### DIFF
--- a/lib/ash_authentication/strategies/password/request_password_reset.ex
+++ b/lib/ash_authentication/strategies/password/request_password_reset.ex
@@ -25,7 +25,7 @@ defmodule AshAuthentication.Strategy.Password.RequestPasswordReset do
       identity = Ash.ActionInput.get_argument(action_input, identity_field)
       select_for_senders = Info.authentication_select_for_senders!(action_input.resource)
       {sender, send_opts} = strategy.resettable.sender
-      send_opts = Keyword.merge(send_opts, Map.to_list(action_input.context))
+      send_opts = Keyword.put(send_opts, :context, action_input.context)
 
       query_result =
         action_input.resource

--- a/lib/ash_authentication/strategies/password/request_password_reset.ex
+++ b/lib/ash_authentication/strategies/password/request_password_reset.ex
@@ -25,6 +25,7 @@ defmodule AshAuthentication.Strategy.Password.RequestPasswordReset do
       identity = Ash.ActionInput.get_argument(action_input, identity_field)
       select_for_senders = Info.authentication_select_for_senders!(action_input.resource)
       {sender, send_opts} = strategy.resettable.sender
+      send_opts = Keyword.merge(send_opts, Map.to_list(action_input.context))
 
       query_result =
         action_input.resource


### PR DESCRIPTION
👋 After talking with Zach Daniel, I provide this PR. It will pass along the context given to the action running https://github.com/team-alembic/ash_authentication/blob/main/lib/ash_authentication/strategies/password/request_password_reset.ex 

```
strategy = Info.strategy!(User, :password)

strategy.resource
|> AshPhoenix.Form.for_action(strategy.resettable.request_password_reset_action_name,
  context: %{otp_app: :foo}
)
```
You can now access `otp_app` under `opts` in the sender using `use AshAuthentication.Sender` resulting in something like:

```
defmodule SendNewUserConfirmationEmail do
  use AshAuthentication.Sender

  ...

  @impl true
  def send(user, token, opts) do
    <-- Here you can do something with opts[:otp_app] -->
  end

  ...
end

```
