### PR TITLE
improvement(Strategy.Custom): The `strategy_module` field is no longer required.

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.Strategy.Slack.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.Slack.md
@@ -8,7 +8,7 @@ Strategy for authenticating using [Slack](https://slack.com)
 This strategy builds on-top of `AshAuthentication.Strategy.Oidc` and
 [`assent`](https://hex.pm/packages/assent).
 
-In order to use GitHub you need to provide the following minimum configuration:
+In order to use Slack you need to provide the following minimum configuration:
 
   - `client_id`
   - `redirect_uri`

--- a/lib/ash_authentication/add_ons/confirmation.ex
+++ b/lib/ash_authentication/add_ons/confirmation.ex
@@ -115,7 +115,6 @@ defmodule AshAuthentication.AddOn.Confirmation do
             provider: :confirmation,
             resource: nil,
             sender: nil,
-            strategy_module: __MODULE__,
             token_lifetime: nil
 
   alias Ash.{Changeset, Resource}
@@ -136,7 +135,6 @@ defmodule AshAuthentication.AddOn.Confirmation do
           provider: :confirmation,
           resource: module,
           sender: nil | {module, keyword},
-          strategy_module: module,
           token_lifetime: hours :: pos_integer
         }
 

--- a/lib/ash_authentication/add_ons/log_out_everywhere.ex
+++ b/lib/ash_authentication/add_ons/log_out_everywhere.ex
@@ -57,8 +57,7 @@ defmodule AshAuthentication.AddOn.LogOutEverywhere do
             include_purposes: nil,
             exclude_purposes: ["revocation"],
             provider: :log_out_everywhere,
-            resource: nil,
-            strategy_module: __MODULE__
+            resource: nil
 
   alias __MODULE__.{Dsl, Transformer, Verifier}
   alias AshAuthentication.Strategy.Custom
@@ -71,8 +70,7 @@ defmodule AshAuthentication.AddOn.LogOutEverywhere do
           argument_name: nil,
           name: :log_out_everywhere,
           provider: :log_out_everywhere,
-          resource: module,
-          strategy_module: module
+          resource: module
         }
 
   defdelegate transform(strategy, dsl), to: Transformer

--- a/lib/ash_authentication/strategies/api_key.ex
+++ b/lib/ash_authentication/strategies/api_key.ex
@@ -27,8 +27,7 @@ defmodule AshAuthentication.Strategy.ApiKey do
             resource: nil,
             sign_in_action_name: nil,
             api_key_hash_attribute: nil,
-            api_key_relationship: nil,
-            strategy_module: nil
+            api_key_relationship: nil
 
   alias AshAuthentication.Strategy.{ApiKey, ApiKey.Transformer, ApiKey.Verifier}
 
@@ -39,8 +38,7 @@ defmodule AshAuthentication.Strategy.ApiKey do
           resource: Ash.Resource.t(),
           sign_in_action_name: atom(),
           api_key_hash_attribute: atom(),
-          api_key_relationship: atom(),
-          strategy_module: module()
+          api_key_relationship: atom()
         }
 
   @doc false

--- a/lib/ash_authentication/strategies/custom.ex
+++ b/lib/ash_authentication/strategies/custom.ex
@@ -19,13 +19,17 @@ defmodule AshAuthentication.Strategy.Custom do
   This is the DSL target for your entity and the struct for which you will
   implement the `AshAuthentication.Strategy` protocol.
 
-  The only required field is `strategy_module` which is used to keep track of
-  which custom strategy created which strategy.
+  The only required field is `resource` which will contain the resource module
+  that the strategy has been added to.
+
+  Optionally, you can include a `strategy_module` field if you're reusing
+  another strategy's entity, and thus the `__struct__` key can't be used to
+  introspect the location of the `transform/2` and `verify/2` callbacks.
   """
   @type strategy :: %{
           required(:__struct__) => module,
-          required(:strategy_module) => module,
           required(:resource) => module,
+          optional(:strategy_module) => module,
           optional(atom) => any
         }
 

--- a/lib/ash_authentication/strategies/custom/verifier.ex
+++ b/lib/ash_authentication/strategies/custom/verifier.ex
@@ -21,12 +21,22 @@ defmodule AshAuthentication.Strategy.Custom.Verifier do
     |> Stream.concat(Info.authentication_add_ons(dsl_state))
     |> Enum.reduce_while(:ok, fn
       strategy, :ok ->
+        strategy_module = strategy_module(strategy)
+
         strategy
-        |> strategy.strategy_module.verify(dsl_state)
+        |> strategy_module.verify(dsl_state)
         |> case do
           :ok -> {:cont, :ok}
           {:error, reason} -> {:halt, {:error, reason}}
         end
     end)
   end
+
+  # This is needed by some strategies which re-use another strategy's entity (ie everything based on oauth2).
+  defp strategy_module(strategy) when is_nil(strategy.strategy_module), do: strategy.__struct__
+
+  defp strategy_module(strategy) when is_atom(strategy.strategy_module),
+    do: strategy.strategy_module
+
+  defp strategy_module(strategy), do: strategy.__struct__
 end

--- a/lib/ash_authentication/strategies/magic_link.ex
+++ b/lib/ash_authentication/strategies/magic_link.ex
@@ -131,7 +131,6 @@ defmodule AshAuthentication.Strategy.MagicLink do
             sender: nil,
             sign_in_action_name: nil,
             single_use_token?: true,
-            strategy_module: __MODULE__,
             token_lifetime: {10, :minutes},
             token_param_name: :token
 
@@ -152,7 +151,6 @@ defmodule AshAuthentication.Strategy.MagicLink do
           sender: {module, keyword},
           sign_in_action_name: atom,
           single_use_token?: boolean,
-          strategy_module: module,
           token_lifetime: pos_integer(),
           token_param_name: atom
         }

--- a/lib/ash_authentication/strategies/password.ex
+++ b/lib/ash_authentication/strategies/password.ex
@@ -112,8 +112,7 @@ defmodule AshAuthentication.Strategy.Password do
             sign_in_enabled?: true,
             sign_in_token_lifetime: 60,
             sign_in_tokens_enabled?: false,
-            sign_in_with_token_action_name: nil,
-            strategy_module: nil
+            sign_in_with_token_action_name: nil
 
   alias Ash.Resource
 
@@ -147,8 +146,7 @@ defmodule AshAuthentication.Strategy.Password do
           sign_in_enabled?: boolean,
           sign_in_token_lifetime: pos_integer,
           sign_in_tokens_enabled?: boolean,
-          sign_in_with_token_action_name: atom,
-          strategy_module: __MODULE__
+          sign_in_with_token_action_name: atom
         }
 
   @doc false

--- a/lib/ash_authentication/strategies/slack.ex
+++ b/lib/ash_authentication/strategies/slack.ex
@@ -7,7 +7,7 @@ defmodule AshAuthentication.Strategy.Slack do
   This strategy builds on-top of `AshAuthentication.Strategy.Oidc` and
   [`assent`](https://hex.pm/packages/assent).
 
-  In order to use GitHub you need to provide the following minimum configuration:
+  In order to use Slack you need to provide the following minimum configuration:
 
     - `client_id`
     - `redirect_uri`

--- a/lib/ash_authentication/validations.ex
+++ b/lib/ash_authentication/validations.ex
@@ -195,7 +195,11 @@ defmodule AshAuthentication.Validations do
           end
 
         {:error,
-         DslError.exception(path: [:authentication, :strategies, strategy.name], message: message)}
+         DslError.exception(
+           path: [:authentication, :strategies, strategy.name],
+           message: message,
+           module: strategy.resource
+         )}
     end
   end
 end

--- a/test/support/example/only_marties_at_the_party.ex
+++ b/test/support/example/only_marties_at_the_party.ex
@@ -6,8 +6,7 @@ defmodule Example.OnlyMartiesAtTheParty do
   defstruct name: :marty,
             case_sensitive?: false,
             name_field: nil,
-            resource: nil,
-            strategy_module: __MODULE__
+            resource: nil
 
   @entity %Spark.Dsl.Entity{
     name: :only_marty,

--- a/test/support/example_multi_tenant/only_marties_at_the_party.ex
+++ b/test/support/example_multi_tenant/only_marties_at_the_party.ex
@@ -6,8 +6,7 @@ defmodule ExampleMultiTenant.OnlyMartiesAtTheParty do
   defstruct name: :marty,
             case_sensitive?: false,
             name_field: nil,
-            resource: nil,
-            strategy_module: __MODULE__
+            resource: nil
 
   @entity %Spark.Dsl.Entity{
     name: :only_marty,


### PR DESCRIPTION
It's only needed when you recycle another strategy's DSL entity as your own. This is done a lot by all the OAuth2 and OIDC strategies which use the same OAuth2 struct behind the scenes.

Closes #992.