### PR TITLE
Return the new_conn instead of the old conn

### DIFF
--- a/documentation/topics/testing.md
+++ b/documentation/topics/testing.md
@@ -55,7 +55,7 @@ defmodule MyAppWeb.ConnCase do
       |> Phoenix.ConnTest.init_test_session(%{})
       |> AshAuthentication.Plug.Helpers.store_in_session(user)
 
-   %{context | conn: conn}
+   %{context | conn: new_conn}
   end
 end
 ```


### PR DESCRIPTION
Fixes an issue with the testing example code, which assigns a `new_conn` but then wrongly returns the old `conn`:

```elixir
    new_conn =
      conn
      |> Phoenix.ConnTest.init_test_session(%{})
      |> AshAuthentication.Plug.Helpers.store_in_session(user)

   %{context | conn: conn}  # <-- Error is here, should be new_conn
```