### PR TITLE
Improve docs for `require_confirmed_with` in password strategy

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.Strategy.Password.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.Password.md
@@ -141,7 +141,7 @@ end
 | [`sign_in_tokens_enabled?`](#authentication-strategies-password-sign_in_tokens_enabled?){: #authentication-strategies-password-sign_in_tokens_enabled? } | `boolean` | `true` | Whether or not to support generating short lived sign in tokens. Requires the resource to have tokens enabled. |
 | [`sign_in_token_lifetime`](#authentication-strategies-password-sign_in_token_lifetime){: #authentication-strategies-password-sign_in_token_lifetime } | `pos_integer \| {pos_integer, :days \| :hours \| :minutes \| :seconds}` | `{60, :seconds}` | A lifetime for which a generated sign in token will be valid, if `sign_in_tokens_enabled?`. Unit defaults to `:seconds`. |
 | [`sign_in_with_token_action_name`](#authentication-strategies-password-sign_in_with_token_action_name){: #authentication-strategies-password-sign_in_with_token_action_name } | `atom` | `:sign_in_with_token` | The name to use for the sign in action. |
-| [`require_confirmed_with`](#authentication-strategies-password-require_confirmed_with){: #authentication-strategies-password-require_confirmed_with } | `atom \| nil` |  | Whether a new account must be confirmed in order to log in. |
+| [`require_confirmed_with`](#authentication-strategies-password-require_confirmed_with){: #authentication-strategies-password-require_confirmed_with } | `atom \| nil` |  | The field that must be non-nil for a user to be allowed to log in. If unset or nil, no confirmation check will be enforced. |
 
 
 ### authentication.strategies.password.resettable

--- a/documentation/topics/testing.md
+++ b/documentation/topics/testing.md
@@ -55,7 +55,7 @@ defmodule MyAppWeb.ConnCase do
       |> Phoenix.ConnTest.init_test_session(%{})
       |> AshAuthentication.Plug.Helpers.store_in_session(user)
 
-   %{context | conn: conn}
+   %{context | conn: new_conn}
   end
 end
 ```

--- a/documentation/tutorials/confirmation.md
+++ b/documentation/tutorials/confirmation.md
@@ -186,9 +186,9 @@ Provided you have your authentication routes hooked up either via `AshAuthentica
 
 ## Blocking unconfirmed users from logging in
 
-The above section explains how to confirm an user account. There's a new directive in the [dsl](https://hexdocs.pm/ash_authentication/dsl-ashauthentication-strategy-password.html#authentication-strategies-password-require_confirmed_with) which can require the user to be confirmed in order to log in.
+The previous section explained how to confirm a user account. AshAuthentication now includes a directive in the [DSL](https://hexdocs.pm/ash_authentication/dsl-ashauthentication-strategy-password.html#authentication-strategies-password-require_confirmed_with) that allows you to require account confirmation before a user can log in.
 
-So:
+For example:
 
 ```
 authentication do
@@ -196,22 +196,25 @@ authentication do
   add_ons do
     confirmation :confirm_new_user do
       ...
+      confirmed_at_field :confirmed_at
     end
   end
 
   strategies do
     strategy :password do
       ...
-      # which confirmation strategy to require confirmation for
-      require_confirmed_with :confirm_new_user
+      # Require confirmation using the specified field
+      require_confirmed_with :confirmed_at
     end
   end
 end
 ```
 
-this will make impossible for unconfirmed users to log in. Note that at the moment it is developer responsibility to handle the scenario, for example redirecting the user to a page that gives some context and maybe offers the chance to require a new confirmation email in case the previous one is lost.
+With this configuration, users whose `confirmed_at` field is `nil` will not be able to log in.
 
-If the field value is `nil` or if the field itself is not present, no confirmation check will be enforced.
+*Note:* It is currently the developer’s responsibility to handle this scenario - for example, by redirecting the user to a page that explains the situation and possibly offers an option to request a new confirmation email if the original one was lost.
+
+If `require_confirmed_with` is not set or set to `nil`, no confirmation check is enforced - unconfirmed users will be allowed to log in.
 
 ## Confirming changes to monitored fields
 

--- a/lib/ash_authentication/strategies/password/dsl.ex
+++ b/lib/ash_authentication/strategies/password/dsl.ex
@@ -135,7 +135,8 @@ defmodule AshAuthentication.Strategy.Password.Dsl do
         require_confirmed_with: [
           type: {:or, [:atom, nil]},
           required: false,
-          doc: "Whether a new account must be confirmed in order to log in.",
+          doc:
+            "The field that must be non-nil for a user to be allowed to log in. If unset or nil, no confirmation check will be enforced.",
           default: nil
         ]
       ],


### PR DESCRIPTION
Clarify that `require_confirmed_with` refers to a field name, not the confirmation add-on.