### PR TITLE
Info.strategy_for_action/2 -> Info.find_strategy/3

### DIFF
--- a/lib/ash_authentication/strategies/api_key/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/api_key/sign_in_preparation.ex
@@ -11,8 +11,8 @@ defmodule AshAuthentication.Strategy.ApiKey.SignInPreparation do
   @doc false
   @impl true
   @spec prepare(Query.t(), keyword, Preparation.Context.t()) :: Query.t()
-  def prepare(query, _opts, _context) do
-    with {:ok, strategy} <- Info.strategy_for_action(query.resource, query.action.name),
+  def prepare(query, opts, context) do
+    with {:ok, strategy} <- Info.find_strategy(query, context, opts),
          {:ok, api_key} <- Query.fetch_argument(query, :api_key),
          {:ok, api_key_id, random_bytes} <- decode_api_key(api_key) do
       api_key_relationship =

--- a/lib/ash_authentication/strategies/magic_link/sign_in_change.ex
+++ b/lib/ash_authentication/strategies/magic_link/sign_in_change.ex
@@ -10,15 +10,16 @@ defmodule AshAuthentication.Strategy.MagicLink.SignInChange do
   @doc false
   @impl true
   @spec change(Changeset.t(), keyword, Change.Context.t()) :: Changeset.t()
-  def change(changeset, _otps, context) do
+  def change(changeset, opts, context) do
     subject_name =
       changeset.resource
       |> Info.authentication_subject_name!()
       |> to_string()
 
-    strategy = Info.strategy_for_action!(changeset.resource, changeset.action.name)
+    {:ok, strategy} = Info.find_strategy(changeset, context, opts)
 
-    with token when is_binary(token) <-
+    with {:ok, strategy} = Info.find_strategy(changeset, context, opts),
+         token when is_binary(token) <-
            Changeset.get_argument(changeset, strategy.token_param_name),
          {:ok, %{"act" => token_action, "sub" => subject, "identity" => identity}, _} <-
            Jwt.verify(token, changeset.resource, [], context),

--- a/lib/ash_authentication/strategies/oauth2/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/oauth2/sign_in_preparation.ex
@@ -18,8 +18,8 @@ defmodule AshAuthentication.Strategy.OAuth2.SignInPreparation do
   @doc false
   @impl true
   @spec prepare(Query.t(), keyword, Preparation.Context.t()) :: Query.t()
-  def prepare(query, _opts, context) do
-    case Info.strategy_for_action(query.resource, query.action.name) do
+  def prepare(query, opts, context) do
+    case Info.find_strategy(query, context, opts) do
       :error ->
         {:error,
          AuthenticationFailed.exception(


### PR DESCRIPTION
Use `Info.find_strategy` for looking up the strategy instead of `Info.strategy_for_action` directly.

The motivation for this change is that `ash_events` does some "clever" wrapping/renaming of actions when tracking events on resources.

When it is used on a resource that is also set up with `AshAuthentication`, the names of the various sign_in-actions get changed, and `Info.strategy_for_action` blows up since there is no strategy defined for the action after it has been renamed to something else than for example `sign_in_with_magic_link`.

The solution is to add a `change set_context(%{strategy_name}, <strategy>)` to the sign-in actions when using `ash_events`, but this will only work if the strategy is determined through `Info.find_strategy` 😅 

For context:
https://github.com/ash-project/ash_events/pull/20