### PR TITLE
fix: set correct default on_error

### DIFF
--- a/lib/ash_authentication/strategies/api_key/plug.ex
+++ b/lib/ash_authentication/strategies/api_key/plug.ex
@@ -92,7 +92,7 @@ defmodule AshAuthentication.Strategy.ApiKey.Plug do
       end
 
     on_error =
-      Keyword.get(opts, :on_error, &on_error/2)
+      Keyword.get(opts, :on_error, &__MODULE__.on_error/2)
 
     %{
       resource: resource,


### PR DESCRIPTION
Noticed this a few days ago implementing the new ApiKey strategy but didn't get around to making a PR yet. A simple fix for meeting Plug.Conn requirements for the default on_error option.