### PR TITLE
improvement: allow configuring extra claims for a user

### DIFF
--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -138,6 +138,11 @@ defmodule AshAuthentication.Dsl do
                   "The resource used to store token information, such as in-flight confirmations, revocations, and if `store_all_tokens?` is enabled, authentication tokens themselves.",
                 required: true
               ],
+              extra_claims: [
+                type: {:or, [{:fun, 2}, :map]},
+                doc:
+                  "A function that takes the user and the options provided when generating a token (contains the tenant), and returns a map of extra claims to include in the token."
+              ],
               signing_secret: [
                 type: secret_type,
                 doc: "The secret used to sign tokens.  #{secret_doc}"

--- a/lib/ash_authentication/plug/helpers.ex
+++ b/lib/ash_authentication/plug/helpers.ex
@@ -101,6 +101,7 @@ defmodule AshAuthentication.Plug.Helpers do
                  resource,
                  opts
                ) do
+          user = Ash.Resource.set_metadata(user, %{claims: claims})
           Conn.assign(conn, current_subject_name, user)
         else
           _ ->
@@ -223,6 +224,8 @@ defmodule AshAuthentication.Plug.Helpers do
              ),
            {:ok, subject_name} <- Info.authentication_subject_name(resource),
            current_subject_name <- current_subject_name(subject_name) do
+        user = Ash.Resource.set_metadata(user, %{claims: claims})
+
         conn
         |> Conn.assign(current_subject_name, user)
         |> maybe_assign_token_record(token_record, subject_name)

--- a/lib/ash_authentication/plug/helpers.ex
+++ b/lib/ash_authentication/plug/helpers.ex
@@ -101,7 +101,6 @@ defmodule AshAuthentication.Plug.Helpers do
                  resource,
                  opts
                ) do
-          user = Ash.Resource.set_metadata(user, %{claims: claims})
           Conn.assign(conn, current_subject_name, user)
         else
           _ ->


### PR DESCRIPTION
This is only half done. We still need to do one thing which is to modify the `store_in_session` helper to 

1. take opts and store the claims in the session so that they can be added to the user in LV hand off or when loading from the session.
2. modify `load_from_session` and `assign_new_resources` to use the claims info from the session.

This allows for 
1. claims to be stored in the token that the client can read
2. those claims to be used for writing policies/checks etc.

Now, in most setups, I would say not to store additional claims in the JWT and then actually use that information for authorization, but it is a legitimate optimization in many cases, or in situations where just being in possession of a given token is sufficient to authorize certain actions etc.