### PR TITLE
Update Auth0 tutorial

### DIFF
--- a/documentation/tutorials/auth0.md
+++ b/documentation/tutorials/auth0.md
@@ -165,7 +165,7 @@ In your auth controller, make sure to add a redirect to `https://[auth0_endpoint
   def sign_out(conn, _params) do
 
     conn
-    |> clear_session()
+    |> clear_session(:my_app)
     |> redirect(external: "https://[auth0_endpoint]/v2/logout?client_id=[auth0_client_id]&returnTo=#{AppWeb.Endpoint.url()}")
   end
 ```


### PR DESCRIPTION
This updates the example sign_out controller action to fix a compiler error. The `clear_session/1` function has been deprecated in favor of `clear_session/2`.