### PR TITLE
DRAFT: improve: API key auth for multi-tenancy resources

### DIFF
--- a/lib/ash_authentication/strategies/api_key.ex
+++ b/lib/ash_authentication/strategies/api_key.ex
@@ -27,7 +27,8 @@ defmodule AshAuthentication.Strategy.ApiKey do
             resource: nil,
             sign_in_action_name: nil,
             api_key_hash_attribute: nil,
-            api_key_relationship: nil
+            api_key_relationship: nil,
+            multitenancy_relationship: nil
 
   alias AshAuthentication.Strategy.{ApiKey, ApiKey.Transformer, ApiKey.Verifier}
 
@@ -38,7 +39,8 @@ defmodule AshAuthentication.Strategy.ApiKey do
           resource: Ash.Resource.t(),
           sign_in_action_name: atom(),
           api_key_hash_attribute: atom(),
-          api_key_relationship: atom()
+          api_key_relationship: atom(),
+          multitenancy_relationship: atom()
         }
 
   @doc false

--- a/lib/ash_authentication/strategies/api_key/dsl.ex
+++ b/lib/ash_authentication/strategies/api_key/dsl.ex
@@ -33,6 +33,10 @@ defmodule AshAuthentication.Strategy.ApiKey.Dsl do
           type: :atom,
           doc:
             "The name to use for the sign in action. Defaults to `sign_in_with_<strategy_name>`"
+        ],
+        multitenancy_relationship: [
+          type: :atom,
+          doc: "The relationship from the API key to the issuing tenant."
         ]
       ]
     }

--- a/lib/ash_authentication/strategies/api_key/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/api_key/sign_in_preparation.ex
@@ -24,6 +24,7 @@ defmodule AshAuthentication.Strategy.ApiKey.SignInPreparation do
         api_key_relationship.destination
         |> Ash.Query.do_filter(api_key_relationship.filter)
         |> Ash.Query.filter(id == ^api_key_id)
+        |> maybe_load_tenant(strategy.multitenancy_relationship)
         |> Query.set_context(%{private: %{ash_authentication?: true}})
         |> Ash.read_one()
         |> case do
@@ -77,6 +78,7 @@ defmodule AshAuthentication.Strategy.ApiKey.SignInPreparation do
         api_key_relationship.source_attribute =>
           Map.get(api_key, api_key_relationship.destination_attribute)
       })
+      |> maybe_set_tenant(api_key, strategy.multitenancy_relationship)
       |> Ash.Query.after_action(fn
         _query, [user] ->
           {:ok,
@@ -132,6 +134,25 @@ defmodule AshAuthentication.Strategy.ApiKey.SignInPreparation do
     else
       _ ->
         :error
+    end
+  end
+
+  defp maybe_load_tenant(query, nil), do: query
+
+  defp maybe_load_tenant(query, multitenancy_relationship) do
+    Ash.Query.load(query, multitenancy_relationship)
+  end
+
+  defp maybe_set_tenant(query, _api_key, nil), do: query
+
+  defp maybe_set_tenant(query, api_key, multitenancy_relationship) do
+    case Map.get(api_key, multitenancy_relationship) do
+      %{__struct__: _} = tenant ->
+        Ash.Query.set_tenant(query, tenant)
+
+      _ ->
+        # Issue a warning or error?
+        query
     end
   end
 end


### PR DESCRIPTION
Introduce optional `multitenancy_relationship` to the API key strategy to allow the authenticated resource to be bound to a tenant.

This is a  follow-up to https://elixirforum.com/t/ashauthentication-with-multi-tenancy-and-api-keys-strategy/

With this patch I can do:
```elixir
defmodule User do
  multitenancy do
    strategy :context
  end

  authentication do
    strategies do
      api_key :api_key do
        api_key_relationship :valid_api_keys
        api_key_hash_attribute :api_key_hash
        multitenancy_relationship :organisation
      end
    end
  end
  # [...]
end
```

Might this be a valid approach?