### PR TITLE
improvement: pass magic link request source context to mail sender

### DIFF
--- a/lib/ash_authentication/strategies/magic_link/request.ex
+++ b/lib/ash_authentication/strategies/magic_link/request.ex
@@ -35,7 +35,13 @@ defmodule AshAuthentication.Strategy.MagicLink.Request do
              {sender, send_opts} <- strategy.sender,
              {:ok, token} <-
                MagicLink.request_token_for_identity(strategy, identity, context_opts, context) do
-          sender.send(to_string(identity), token, Keyword.put(send_opts, :tenant, context.tenant))
+          build_opts =
+            Keyword.merge(send_opts,
+              tenant: context.tenant,
+              source_context: context.source_context
+            )
+
+          sender.send(to_string(identity), token, build_opts)
 
           :ok
         else
@@ -47,7 +53,13 @@ defmodule AshAuthentication.Strategy.MagicLink.Request do
         with {sender, send_opts} <- strategy.sender,
              {:ok, token} <-
                MagicLink.request_token_for_identity(strategy, identity, context_opts, context) do
-          sender.send(user, token, Keyword.put(send_opts, :tenant, context.tenant))
+          build_opts =
+            Keyword.merge(send_opts,
+              tenant: context.tenant,
+              source_context: context.source_context
+            )
+
+          sender.send(user, token, build_opts)
 
           :ok
         else


### PR DESCRIPTION
This change helps to pass context to the mail sender.

This can be used to send a specific mail template to the user after an event happened to inform the user and provide a magic link to view information about the event in the application.