### PR TITLE
feat: enhance error messages in hash_password_change.ex

### DIFF
--- a/lib/ash_authentication/strategies/password/hash_password_change.ex
+++ b/lib/ash_authentication/strategies/password/hash_password_change.ex
@@ -43,34 +43,8 @@ defmodule AshAuthentication.Strategy.Password.HashPasswordChange do
   @impl true
   @spec change(Changeset.t(), keyword, Change.context()) :: Changeset.t()
   def change(changeset, options, context) do
-    changeset
-    |> Changeset.before_action(fn changeset ->
-      case Info.find_strategy(changeset, context, options) do
-        {:ok, strategy} ->
-          value = Changeset.get_argument(changeset, strategy.password_field)
-          if is_binary(value) do
-            case strategy.hash_provider.hash(value) do
-              {:ok, hash} ->
-                Changeset.force_change_attribute(changeset, strategy.hashed_password_field, hash)
-              :error ->
-                raise AssumptionFailed, message: "Error hashing password with #{inspect(strategy.hash_provider)}."
-            end
-          else
-            changeset
-          end
-
-        :error ->
-          raise AssumptionFailed,
-            message: """
-            Strategy not found for action #{changeset.action.name}.
-
-            Add strategy context to your action:
-            change set_context(%{strategy_name: :password})
-
-            Or set it on the changeset:
-            changeset |> Ash.Changeset.set_context(%{strategy_name: :password})
-            """
-      end
+    Changeset.before_action(changeset, fn changeset ->
+      hash_password_in_changeset(changeset, context, options)
     end)
   end
 
@@ -99,5 +73,46 @@ defmodule AshAuthentication.Strategy.Password.HashPasswordChange do
       :error ->
         raise AssumptionFailed, message: "Error hashing password."
     end
+  end
+
+  defp hash_password_in_changeset(changeset, context, options) do
+    case Info.find_strategy(changeset, context, options) do
+      {:ok, strategy} -> apply_password_hashing(changeset, strategy)
+      :error -> raise_strategy_not_found_error(changeset)
+    end
+  end
+
+  defp apply_password_hashing(changeset, strategy) do
+    value = Changeset.get_argument(changeset, strategy.password_field)
+
+    if is_binary(value) do
+      hash_and_update_changeset(changeset, strategy, value)
+    else
+      changeset
+    end
+  end
+
+  defp hash_and_update_changeset(changeset, strategy, value) do
+    case strategy.hash_provider.hash(value) do
+      {:ok, hash} ->
+        Changeset.force_change_attribute(changeset, strategy.hashed_password_field, hash)
+
+      :error ->
+        raise AssumptionFailed,
+          message: "Error hashing password with #{inspect(strategy.hash_provider)}."
+    end
+  end
+
+  defp raise_strategy_not_found_error(changeset) do
+    raise AssumptionFailed,
+      message: """
+      Strategy not found for action #{changeset.action.name}.
+
+      Add strategy context to your action:
+      change set_context(%{strategy_name: :password})
+
+      Or set it on the changeset:
+      changeset |> Ash.Changeset.set_context(%{strategy_name: :password})
+      """
   end
 end


### PR DESCRIPTION
Updated `change` method in `AshAuthentication.Strategy.Password.HashPasswordChange` per issue #1057 