### PR TITLE
Create action validation behaviour, make module configurable in DSL.

### DIFF
--- a/lib/ash_authentication/add_ons/confirmation/transformer.ex
+++ b/lib/ash_authentication/add_ons/confirmation/transformer.ex
@@ -5,13 +5,11 @@ defmodule AshAuthentication.AddOn.Confirmation.Transformer do
   Ensures that there is only ever one present and that it is correctly
   configured.
   """
-
   alias Ash.{Resource, Type}
   alias AshAuthentication.{AddOn.Confirmation, GenerateTokenChange}
   alias Spark.{Dsl.Transformer, Error.DslError}
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Validations.Attribute
   import AshAuthentication.Strategy.Custom.Helpers
 
@@ -172,11 +170,16 @@ defmodule AshAuthentication.AddOn.Confirmation.Transformer do
   end
 
   defp validate_confirm_action(dsl_state, strategy) do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.confirm_action_name),
-         :ok <- validate_action_has_change(action, Confirmation.ConfirmChange),
-         :ok <- validate_action_argument_option(action, :confirm, :allow_nil?, [false]),
-         :ok <- validate_action_argument_option(action, :confirm, :type, [Type.String]),
-         :ok <- validate_action_has_change(action, GenerateTokenChange) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.confirm_action_name),
+         :ok <- action_validator.validate_action_has_change(action, Confirmation.ConfirmChange),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :confirm, :allow_nil?, [false]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :confirm, :type, [Type.String]),
+         :ok <- action_validator.validate_action_has_change(action, GenerateTokenChange) do
       accept_fields = MapSet.new(action.accept || [])
 
       strategy.monitor_fields

--- a/lib/ash_authentication/add_ons/log_out_everywhere/transformer.ex
+++ b/lib/ash_authentication/add_ons/log_out_everywhere/transformer.ex
@@ -12,7 +12,6 @@ defmodule AshAuthentication.AddOn.LogOutEverywhere.Transformer do
   alias Spark.{Dsl.Transformer, Error.DslError}
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Strategy.Custom.Helpers
 
   @doc false
@@ -83,20 +82,34 @@ defmodule AshAuthentication.AddOn.LogOutEverywhere.Transformer do
   end
 
   defp validate_log_out_action(dsl, strategy) do
-    with {:ok, action} <- validate_action_exists(dsl, strategy.action_name),
-         :ok <- validate_action_option(action, :type, [:action]),
-         :ok <- validate_action_option(action, :returns, [nil]),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl, strategy.action_name),
+         :ok <- action_validator.validate_action_option(action, :type, [:action]),
+         :ok <- action_validator.validate_action_option(action, :returns, [nil]),
          :ok <-
-           validate_action_option(action, :run, [
+           action_validator.validate_action_option(action, :run, [
              LogOutEverywhere.Action,
              {LogOutEverywhere.Action, []}
            ]),
-         :ok <- validate_action_has_argument(action, strategy.argument_name),
+         :ok <- action_validator.validate_action_has_argument(action, strategy.argument_name),
          :ok <-
-           validate_action_argument_option(action, strategy.argument_name, :type, [
-             Ash.Type.Struct
-           ]) do
-      validate_action_argument_option(action, strategy.argument_name, :allow_nil?, [false])
+           action_validator.validate_action_argument_option(
+             action,
+             strategy.argument_name,
+             :type,
+             [
+               Ash.Type.Struct
+             ]
+           ) do
+      action_validator.validate_action_argument_option(
+        action,
+        strategy.argument_name,
+        :allow_nil?,
+        [
+          false
+        ]
+      )
     end
   end
 

--- a/lib/ash_authentication/dsl.ex
+++ b/lib/ash_authentication/dsl.ex
@@ -9,6 +9,7 @@ defmodule AshAuthentication.Dsl do
   import Joken.Signer, only: [algorithms: 0]
 
   alias Ash.{Domain, Resource}
+  alias AshAuthentication.Validators.ActionValidators
 
   @default_token_lifetime_days 14
 
@@ -94,6 +95,12 @@ defmodule AshAuthentication.Dsl do
             type: {:list, :atom},
             doc:
               "A list of fields that we will ensure are selected whenever a sender will be invoked.  Defaults to `[:email]` if there is an `:email` attribute on the resource, and `[]` otherwise."
+          ],
+          action_validators: [
+            type: {:behaviour, ActionValidators},
+            doc:
+              "A module that implements the `ActionValidators` behaviour. Defaults to `AshAuthentication.Validators.Action`.",
+            default: AshAuthentication.Validations.Action
           ]
         ],
         sections: [

--- a/lib/ash_authentication/strategies/api_key/verifier.ex
+++ b/lib/ash_authentication/strategies/api_key/verifier.ex
@@ -8,7 +8,6 @@ defmodule AshAuthentication.Strategy.ApiKey.Verifier do
   alias Spark.Dsl.Transformer
   alias Spark.Error.DslError
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
 
   @doc false
   @spec verify(ApiKey.t(), map) :: :ok | {:error, Exception.t()}
@@ -107,17 +106,20 @@ defmodule AshAuthentication.Strategy.ApiKey.Verifier do
   end
 
   defp validate_sign_in_action(dsl_state, strategy) do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.sign_in_action_name),
-         :ok <- validate_action_has_argument(action, :api_key),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.sign_in_action_name),
+         :ok <- action_validator.validate_action_has_argument(action, :api_key),
          :ok <-
-           validate_action_argument_option(action, :api_key, :type, [
+           action_validator.validate_action_argument_option(action, :api_key, :type, [
              :string,
              Ash.Type.String
            ]),
          :ok <-
-           validate_action_argument_option(action, :api_key, :allow_nil?, [false]),
+           action_validator.validate_action_argument_option(action, :api_key, :allow_nil?, [false]),
          :ok <- validate_field_in_values(action, :type, [:read]) do
-      validate_action_has_preparation(action, ApiKey.SignInPreparation)
+      action_validator.validate_action_has_preparation(action, ApiKey.SignInPreparation)
     else
       {:error, message} when is_binary(message) ->
         {:error,

--- a/lib/ash_authentication/strategies/magic_link/verifier.ex
+++ b/lib/ash_authentication/strategies/magic_link/verifier.ex
@@ -6,7 +6,6 @@ defmodule AshAuthentication.Strategy.MagicLink.Verifier do
   alias AshAuthentication.{Strategy.MagicLink}
   alias Spark.Error.DslError
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Validations.Attribute
 
   @doc false
@@ -32,39 +31,54 @@ defmodule AshAuthentication.Strategy.MagicLink.Verifier do
   end
 
   defp validate_request_action(dsl_state, strategy, identity_attribute) do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.request_action_name),
-         :ok <- validate_action_has_argument(action, strategy.identity_field),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.request_action_name),
+         :ok <- action_validator.validate_action_has_argument(action, strategy.identity_field),
          :ok <-
-           validate_action_argument_option(
+           action_validator.validate_action_argument_option(
              action,
              strategy.identity_field,
              :type,
              [identity_attribute.type]
            ),
          :ok <-
-           validate_action_argument_option(action, strategy.identity_field, :allow_nil?, [
-             false
-           ]),
+           action_validator.validate_action_argument_option(
+             action,
+             strategy.identity_field,
+             :allow_nil?,
+             [
+               false
+             ]
+           ),
          :ok <- validate_field_in_values(action, :type, [:read, :action]) do
       case action.type do
         :read ->
-          validate_action_has_preparation(action, MagicLink.RequestPreparation)
+          action_validator.validate_action_has_preparation(action, MagicLink.RequestPreparation)
 
         _ ->
-          with {:ok, action} <- validate_action_exists(dsl_state, strategy.lookup_action_name),
-               :ok <- validate_action_has_argument(action, identity_attribute.name),
+          with {:ok, action} <-
+                 action_validator.validate_action_exists(dsl_state, strategy.lookup_action_name),
                :ok <-
-                 validate_action_argument_option(
+                 action_validator.validate_action_has_argument(action, identity_attribute.name),
+               :ok <-
+                 action_validator.validate_action_argument_option(
                    action,
                    strategy.identity_field,
                    :type,
                    [identity_attribute.type]
                  ),
                :ok <-
-                 validate_action_argument_option(action, strategy.identity_field, :allow_nil?, [
-                   false
-                 ]),
-               :ok <- validate_action_option(action, :get?, [true]) do
+                 action_validator.validate_action_argument_option(
+                   action,
+                   strategy.identity_field,
+                   :allow_nil?,
+                   [
+                     false
+                   ]
+                 ),
+               :ok <- action_validator.validate_action_option(action, :get?, [true]) do
             :ok
           else
             {:error, error} ->
@@ -85,21 +99,34 @@ defmodule AshAuthentication.Strategy.MagicLink.Verifier do
   end
 
   defp validate_sign_in_action(dsl_state, strategy) do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.sign_in_action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.sign_in_action_name),
          :ok <- validate_sign_in_action_type(action, strategy),
-         :ok <- validate_action_has_argument(action, strategy.token_param_name),
+         :ok <- action_validator.validate_action_has_argument(action, strategy.token_param_name),
          :ok <-
-           validate_action_argument_option(action, strategy.token_param_name, :type, [
-             :string,
-             Ash.Type.String
-           ]),
+           action_validator.validate_action_argument_option(
+             action,
+             strategy.token_param_name,
+             :type,
+             [
+               :string,
+               Ash.Type.String
+             ]
+           ),
          :ok <-
-           validate_action_argument_option(action, strategy.token_param_name, :allow_nil?, [false]),
+           action_validator.validate_action_argument_option(
+             action,
+             strategy.token_param_name,
+             :allow_nil?,
+             [false]
+           ),
          :ok <- validate_field_in_values(action, :type, [:read, :create]) do
       if action.type == :read do
-        validate_action_has_preparation(action, MagicLink.SignInPreparation)
+        action_validator.validate_action_has_preparation(action, MagicLink.SignInPreparation)
       else
-        validate_action_has_change(action, MagicLink.SignInChange)
+        action_validator.validate_action_has_change(action, MagicLink.SignInChange)
       end
     else
       {:error, message} when is_binary(message) ->
@@ -126,11 +153,11 @@ defmodule AshAuthentication.Strategy.MagicLink.Verifier do
     message =
       if enabled? do
         """
-        When registration is not enabled for magic link authentication, 
-        the action: #{inspect(resource)}.#{name} must be a :create action. 
+        When registration is not enabled for magic link authentication,
+        the action: #{inspect(resource)}.#{name} must be a :create action.
         Got an action of type: #{inspect(type)}.
 
-        You can either remove the action definition to use the default one, 
+        You can either remove the action definition to use the default one,
         or replace it with an action like this:
 
             create :#{name} do
@@ -155,11 +182,11 @@ defmodule AshAuthentication.Strategy.MagicLink.Verifier do
         """
       else
         """
-        When registration is not enabled for magic link authentication, 
-        the action: #{inspect(resource)}.#{name} must be a :read action. 
+        When registration is not enabled for magic link authentication,
+        the action: #{inspect(resource)}.#{name} must be a :read action.
         Got an action of type: #{inspect(type)}.
 
-        You can either remove the action definition to use the default one, 
+        You can either remove the action definition to use the default one,
         or replace it with an action like this:
 
             read :#{name} do

--- a/lib/ash_authentication/strategies/oauth2/transformer.ex
+++ b/lib/ash_authentication/strategies/oauth2/transformer.ex
@@ -12,7 +12,6 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
   import AshAuthentication.Strategy.Custom.Helpers
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
 
   @doc false
   @spec transform(OAuth2.t(), map) :: {:ok, OAuth2.t() | map} | {:error, Exception.t()}
@@ -76,14 +75,30 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
   end
 
   defp maybe_validate_register_action(dsl_state, strategy) when strategy.registration_enabled? do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.register_action_name),
-         :ok <- validate_action_has_argument(action, :user_info),
-         :ok <- validate_action_argument_option(action, :user_info, :type, [Type.Map, :map]),
-         :ok <- validate_action_argument_option(action, :user_info, :allow_nil?, [false]),
-         :ok <- validate_action_has_argument(action, :oauth_tokens),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.register_action_name),
+         :ok <- action_validator.validate_action_has_argument(action, :user_info),
          :ok <-
-           validate_action_argument_option(action, :oauth_tokens, :type, [Type.Map, :map]),
-         :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
+           action_validator.validate_action_argument_option(action, :user_info, :type, [
+             Type.Map,
+             :map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :user_info, :allow_nil?, [
+             false
+           ]),
+         :ok <- action_validator.validate_action_has_argument(action, :oauth_tokens),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :type, [
+             Type.Map,
+             :map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [
+             false
+           ]),
          :ok <- maybe_validate_action_has_token_change(dsl_state, action),
          :ok <- validate_field_in_values(action, :upsert?, [true]),
          :ok <-
@@ -93,7 +108,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
              &(is_atom(&1) and not is_falsy(&1)),
              "Expected `upsert_identity` to be set"
            ),
-         :ok <- maybe_validate_action_has_identity_change(action, strategy) do
+         :ok <- maybe_validate_action_has_identity_change(dsl_state, action, strategy) do
       :ok
     else
       {:error, reason} when is_binary(reason) ->
@@ -108,32 +123,51 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
 
   defp maybe_validate_action_has_token_change(dsl_state, action) do
     if Info.authentication_tokens_enabled?(dsl_state) do
-      validate_action_has_change(action, GenerateTokenChange)
+      action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+      action_validator.validate_action_has_change(action, GenerateTokenChange)
     else
       :ok
     end
   end
 
-  defp maybe_validate_action_has_identity_change(_action, strategy)
+  defp maybe_validate_action_has_identity_change(_dsl_state, _action, strategy)
        when is_falsy(strategy.identity_resource),
        do: :ok
 
-  defp maybe_validate_action_has_identity_change(action, _strategy),
-    do: validate_action_has_change(action, OAuth2.IdentityChange)
+  defp maybe_validate_action_has_identity_change(dsl_state, action, _strategy) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+    action_validator.validate_action_has_change(action, OAuth2.IdentityChange)
+  end
 
   defp maybe_validate_sign_in_action(_dsl_state, strategy) when strategy.registration_enabled?,
     do: :ok
 
   defp maybe_validate_sign_in_action(dsl_state, strategy) do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.sign_in_action_name),
-         :ok <- validate_action_has_argument(action, :user_info),
-         :ok <- validate_action_argument_option(action, :user_info, :type, [Ash.Type.Map, :map]),
-         :ok <- validate_action_argument_option(action, :user_info, :allow_nil?, [false]),
-         :ok <- validate_action_has_argument(action, :oauth_tokens),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.sign_in_action_name),
+         :ok <- action_validator.validate_action_has_argument(action, :user_info),
          :ok <-
-           validate_action_argument_option(action, :oauth_tokens, :type, [Ash.Type.Map, :map]),
-         :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
-         :ok <- validate_action_has_preparation(action, OAuth2.SignInPreparation) do
+           action_validator.validate_action_argument_option(action, :user_info, :type, [
+             Ash.Type.Map,
+             :map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :user_info, :allow_nil?, [
+             false
+           ]),
+         :ok <- action_validator.validate_action_has_argument(action, :oauth_tokens),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :type, [
+             Ash.Type.Map,
+             :map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [
+             false
+           ]),
+         :ok <- action_validator.validate_action_has_preparation(action, OAuth2.SignInPreparation) do
       :ok
     else
       {:error, reason} -> {:error, reason}

--- a/lib/ash_authentication/strategies/password/transformer.ex
+++ b/lib/ash_authentication/strategies/password/transformer.ex
@@ -12,7 +12,6 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
   import AshAuthentication.Strategy.Custom.Helpers
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Validations.Attribute
 
   @doc false
@@ -199,17 +198,22 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
 
   defp validate_register_action(dsl_state, strategy)
        when strategy.registration_enabled? == true do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.register_action_name),
-         :ok <- validate_password_argument(action, strategy.password_field, true),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.register_action_name),
+         :ok <- validate_password_argument(dsl_state, action, strategy.password_field, true),
          :ok <-
            validate_password_argument(
+             dsl_state,
              action,
              strategy.password_confirmation_field,
              strategy.confirmation_required?
            ),
-         :ok <- validate_action_has_change(action, Password.HashPasswordChange),
-         :ok <- validate_action_has_change(action, GenerateTokenChange) do
+         :ok <- action_validator.validate_action_has_change(action, Password.HashPasswordChange),
+         :ok <- action_validator.validate_action_has_change(action, GenerateTokenChange) do
       validate_action_has_validation(
+        dsl_state,
         action,
         Password.PasswordConfirmationValidation,
         strategy.confirmation_required?
@@ -219,18 +223,28 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
 
   defp validate_register_action(_dsl_state, _strategy), do: :ok
 
-  defp validate_password_argument(action, field, true) do
-    with :ok <- validate_action_argument_option(action, field, :type, [Ash.Type.String]) do
-      validate_action_argument_option(action, field, :sensitive?, [true])
+  defp validate_password_argument(dsl_state, action, field, true) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with :ok <-
+           action_validator.validate_action_argument_option(action, field, :type, [
+             Ash.Type.String
+           ]) do
+      action_validator.validate_action_argument_option(action, field, :sensitive?, [true])
     end
   end
 
-  defp validate_password_argument(_action, _field, _), do: :ok
+  defp validate_password_argument(_dsl_state, _action, _field, _), do: :ok
 
-  defp validate_action_has_validation(action, validation, true),
-    do: validate_action_has_validation(action, validation)
+  defp validate_action_has_validation(dsl_state, action, validation) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+    action_validator.validate_action_has_validation(action, validation)
+  end
 
-  defp validate_action_has_validation(_action, _validation, _), do: :ok
+  defp validate_action_has_validation(dsl_state, action, validation, true),
+    do: validate_action_has_validation(dsl_state, action, validation)
+
+  defp validate_action_has_validation(_dsl_state, _action, _validation, _), do: :ok
 
   defp build_sign_in_action(dsl_state, strategy) do
     identity_attribute = Resource.Info.attribute(dsl_state, strategy.identity_field)
@@ -282,18 +296,25 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
   end
 
   defp validate_sign_in_action(dsl_state, strategy) when strategy.sign_in_enabled? == true do
-    with {:ok, action} <- validate_action_exists(dsl_state, strategy.sign_in_action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, strategy.sign_in_action_name),
          :ok <- validate_identity_argument(dsl_state, action, strategy.identity_field),
-         :ok <- validate_password_argument(action, strategy.password_field, true) do
-      validate_action_has_preparation(action, Password.SignInPreparation)
+         :ok <- validate_password_argument(dsl_state, action, strategy.password_field, true) do
+      action_validator.validate_action_has_preparation(action, Password.SignInPreparation)
     end
   end
 
   defp validate_sign_in_action(_dsl_state, _strategy), do: :ok
 
   defp validate_identity_argument(dsl_state, action, identity_field) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
     identity_attribute = Ash.Resource.Info.attribute(dsl_state, identity_field)
-    validate_action_argument_option(action, identity_field, :type, [identity_attribute.type])
+
+    action_validator.validate_action_argument_option(action, identity_field, :type, [
+      identity_attribute.type
+    ])
   end
 
   defp build_sign_in_with_token_action(_dsl_state, strategy) do
@@ -334,20 +355,34 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
 
   defp validate_sign_in_with_token_action(dsl_state, strategy)
        when strategy.sign_in_tokens_enabled? == true do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with {:ok, action} <-
-           validate_action_exists(dsl_state, strategy.sign_in_with_token_action_name),
-         :ok <- validate_token_argument(action) do
-      validate_action_has_preparation(action, Password.SignInWithTokenPreparation)
+           action_validator.validate_action_exists(
+             dsl_state,
+             strategy.sign_in_with_token_action_name
+           ),
+         :ok <- validate_token_argument(dsl_state, action) do
+      action_validator.validate_action_has_preparation(
+        action,
+        Password.SignInWithTokenPreparation
+      )
     end
   end
 
   defp validate_sign_in_with_token_action(_dsl_state, _strategy), do: :ok
 
-  defp validate_token_argument(action) do
+  defp validate_token_argument(dsl_state, action) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with :ok <-
-           validate_action_argument_option(action, :token, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :token, :allow_nil?, [false]) do
-      validate_action_argument_option(action, :token, :sensitive?, [true])
+           action_validator.validate_action_argument_option(action, :token, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :token, :allow_nil?, [false]) do
+      action_validator.validate_action_argument_option(action, :token, :sensitive?, [true])
     end
   end
 
@@ -424,11 +459,19 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
   end
 
   defp validate_reset_request_action(dsl_state, resettable, strategy) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with {:ok, action} <-
-           validate_action_exists(dsl_state, resettable.request_password_reset_action_name),
+           action_validator.validate_action_exists(
+             dsl_state,
+             resettable.request_password_reset_action_name
+           ),
          :ok <- validate_identity_argument(dsl_state, action, strategy.identity_field) do
       if action.type == :read do
-        validate_action_has_preparation(action, Password.RequestPasswordResetPreparation)
+        action_validator.validate_action_has_preparation(
+          action,
+          Password.RequestPasswordResetPreparation
+        )
       else
         :ok
       end
@@ -510,24 +553,31 @@ defmodule AshAuthentication.Strategy.Password.Transformer do
   end
 
   defp validate_reset_action(dsl_state, resettable, strategy) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with {:ok, action} <-
-           validate_action_exists(dsl_state, resettable.password_reset_action_name),
-         :ok <- validate_action_has_validation(action, Password.ResetTokenValidation),
-         :ok <- validate_action_has_change(action, Password.HashPasswordChange),
-         :ok <- validate_password_argument(action, strategy.password_field, true),
+           action_validator.validate_action_exists(
+             dsl_state,
+             resettable.password_reset_action_name
+           ),
+         :ok <- validate_action_has_validation(dsl_state, action, Password.ResetTokenValidation),
+         :ok <- action_validator.validate_action_has_change(action, Password.HashPasswordChange),
+         :ok <- validate_password_argument(dsl_state, action, strategy.password_field, true),
          :ok <-
            validate_password_argument(
+             dsl_state,
              action,
              strategy.password_confirmation_field,
              strategy.confirmation_required?
            ),
          :ok <-
            validate_action_has_validation(
+             dsl_state,
              action,
              Password.PasswordConfirmationValidation,
              strategy.confirmation_required?
            ) do
-      validate_action_has_change(action, GenerateTokenChange)
+      action_validator.validate_action_has_change(action, GenerateTokenChange)
     end
   end
 end

--- a/lib/ash_authentication/token_resource/transformer.ex
+++ b/lib/ash_authentication/token_resource/transformer.ex
@@ -14,7 +14,6 @@ defmodule AshAuthentication.TokenResource.Transformer do
 
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Validations.Attribute
 
   @doc false
@@ -264,16 +263,31 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_get_token_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
          :ok <-
-           validate_action_argument_option(action, :token, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :token, :allow_nil?, [true]),
-         :ok <- validate_action_argument_option(action, :token, :sensitive?, [true]),
-         :ok <- validate_action_argument_option(action, :jti, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :jti, :allow_nil?, [true]),
+           action_validator.validate_action_argument_option(action, :token, :type, [
+             Ash.Type.String,
+             :string
+           ]),
          :ok <-
-           validate_action_argument_option(action, :purpose, :type, [Ash.Type.String, :string]) do
-      validate_action_has_preparation(action, TokenResource.GetTokenPreparation)
+           action_validator.validate_action_argument_option(action, :token, :allow_nil?, [true]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :token, :sensitive?, [true]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :jti, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :jti, :allow_nil?, [true]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :purpose, :type, [
+             Ash.Type.String,
+             :string
+           ]) do
+      action_validator.validate_action_has_preparation(action, TokenResource.GetTokenPreparation)
     end
   end
 
@@ -311,9 +325,11 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_store_token_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
-         :ok <- validate_token_argument(action) do
-      validate_action_has_change(action, TokenResource.StoreTokenChange)
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
+         :ok <- validate_token_argument(dsl_state, action) do
+      action_validator.validate_action_has_change(action, TokenResource.StoreTokenChange)
     end
   end
 
@@ -366,9 +382,14 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_store_confirmation_changes_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
-         :ok <- validate_token_argument(action) do
-      validate_action_has_change(action, TokenResource.StoreConfirmationChangesChange)
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
+         :ok <- validate_token_argument(dsl_state, action) do
+      action_validator.validate_action_has_change(
+        action,
+        TokenResource.StoreConfirmationChangesChange
+      )
     end
   end
 
@@ -397,10 +418,16 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_get_confirmation_changes_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
-         :ok <- validate_action_argument_option(action, :jti, :type, [Ash.Type.String, :string]),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
          :ok <-
-           validate_action_has_preparation(
+           action_validator.validate_action_argument_option(action, :jti, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_has_preparation(
              action,
              TokenResource.GetConfirmationChangesPreparation
            ) do
@@ -423,25 +450,44 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_read_expired_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name) do
       validate_field_in_values(action, :type, [:read])
     end
   end
 
   defp validate_is_revoked_action(dsl_state, action_name) do
-    case validate_action_exists(dsl_state, action_name) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    case action_validator.validate_action_exists(dsl_state, action_name) do
       {:ok, %{type: :read} = action} ->
         with :ok <-
-               validate_action_argument_option(action, :token, :type, [Ash.Type.String, :string]),
+               action_validator.validate_action_argument_option(action, :token, :type, [
+                 Ash.Type.String,
+                 :string
+               ]),
              :ok <-
-               validate_action_argument_option(action, :jti, :type, [Ash.Type.String, :string]) do
-          validate_action_has_preparation(action, TokenResource.IsRevokedPreparation)
+               action_validator.validate_action_argument_option(action, :jti, :type, [
+                 Ash.Type.String,
+                 :string
+               ]) do
+          action_validator.validate_action_has_preparation(
+            action,
+            TokenResource.IsRevokedPreparation
+          )
         end
 
       {:ok, %{type: :action} = action} ->
         with :ok <-
-               validate_action_argument_option(action, :token, :type, [Ash.Type.String, :string]) do
-          validate_action_argument_option(action, :jti, :type, [Ash.Type.String, :string])
+               action_validator.validate_action_argument_option(action, :token, :type, [
+                 Ash.Type.String,
+                 :string
+               ]) do
+          action_validator.validate_action_argument_option(action, :jti, :type, [
+            Ash.Type.String,
+            :string
+          ])
         end
 
       {:ok, _} ->
@@ -487,34 +533,55 @@ defmodule AshAuthentication.TokenResource.Transformer do
     )
   end
 
-  defp validate_subject_argument(action) do
+  defp validate_subject_argument(dsl_state, action) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with :ok <-
-           validate_action_argument_option(action, :subject, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :subject, :allow_nil?, [false]) do
-      validate_action_argument_option(action, :subject, :sensitive?, [true])
+           action_validator.validate_action_argument_option(action, :subject, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :subject, :allow_nil?, [false]) do
+      action_validator.validate_action_argument_option(action, :subject, :sensitive?, [true])
     end
   end
 
-  defp validate_token_argument(action) do
+  defp validate_token_argument(dsl_state, action) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with :ok <-
-           validate_action_argument_option(action, :token, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :token, :allow_nil?, [false]) do
-      validate_action_argument_option(action, :token, :sensitive?, [true])
+           action_validator.validate_action_argument_option(action, :token, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :token, :allow_nil?, [false]) do
+      action_validator.validate_action_argument_option(action, :token, :sensitive?, [true])
     end
   end
 
-  defp validate_jti_argument(action) do
+  defp validate_jti_argument(dsl_state, action) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with :ok <-
-           validate_action_argument_option(action, :jti, :type, [Ash.Type.String, :string]),
-         :ok <- validate_action_argument_option(action, :jti, :allow_nil?, [false]) do
-      validate_action_argument_option(action, :jti, :sensitive?, [true])
+           action_validator.validate_action_argument_option(action, :jti, :type, [
+             Ash.Type.String,
+             :string
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :jti, :allow_nil?, [false]) do
+      action_validator.validate_action_argument_option(action, :jti, :sensitive?, [true])
     end
   end
 
   defp validate_revoke_token_action(dsl_state, revoke_token_action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, revoke_token_action_name),
-         :ok <- validate_token_argument(action) do
-      validate_action_has_change(action, TokenResource.RevokeTokenChange)
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, revoke_token_action_name),
+         :ok <- validate_token_argument(dsl_state, action) do
+      action_validator.validate_action_has_change(action, TokenResource.RevokeTokenChange)
     end
   end
 
@@ -544,10 +611,13 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_revoke_jti_action(dsl_state, revoke_jti_action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, revoke_jti_action_name),
-         :ok <- validate_jti_argument(action),
-         :ok <- validate_subject_argument(action) do
-      validate_action_has_change(action, TokenResource.RevokeJtiChange)
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <-
+           action_validator.validate_action_exists(dsl_state, revoke_jti_action_name),
+         :ok <- validate_jti_argument(dsl_state, action),
+         :ok <- validate_subject_argument(dsl_state, action) do
+      action_validator.validate_action_has_change(action, TokenResource.RevokeJtiChange)
     end
   end
 
@@ -586,10 +656,18 @@ defmodule AshAuthentication.TokenResource.Transformer do
          dsl_state,
          revoke_all_stored_for_subject_action_name
        ) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
     with {:ok, action} <-
-           validate_action_exists(dsl_state, revoke_all_stored_for_subject_action_name),
-         :ok <- validate_subject_argument(action) do
-      validate_action_has_change(action, TokenResource.RevokeAllStoredForSubjectChange)
+           action_validator.validate_action_exists(
+             dsl_state,
+             revoke_all_stored_for_subject_action_name
+           ),
+         :ok <- validate_subject_argument(dsl_state, action) do
+      action_validator.validate_action_has_change(
+        action,
+        TokenResource.RevokeAllStoredForSubjectChange
+      )
     end
   end
 
@@ -618,7 +696,9 @@ defmodule AshAuthentication.TokenResource.Transformer do
   end
 
   defp validate_expunge_expired_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name) do
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name) do
       validate_field_in_values(action, :type, [:destroy])
     end
   end

--- a/lib/ash_authentication/token_resource/verifier.ex
+++ b/lib/ash_authentication/token_resource/verifier.ex
@@ -8,7 +8,6 @@ defmodule AshAuthentication.TokenResource.Verifier do
   require Logger
   alias Spark.{Dsl.Verifier, Error.DslError}
   import AshAuthentication.Utils
-  import AshAuthentication.Validations.Action
 
   @doc false
   @impl true
@@ -25,7 +24,9 @@ defmodule AshAuthentication.TokenResource.Verifier do
         :ok
 
       action_name ->
-        case validate_action_exists(dsl_state, action_name) do
+        action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+        case action_validator.validate_action_exists(dsl_state, action_name) do
           {:ok, action} -> validate_is_revoked_action(dsl_state, action)
           {:error, _} -> :ok
         end
@@ -34,9 +35,17 @@ defmodule AshAuthentication.TokenResource.Verifier do
 
   defp validate_is_revoked_action(dsl_state, action) do
     if action.type == :action do
-      with :ok <- validate_action_argument_option(action, :jti, :allow_nil?, [true]),
-           :ok <- validate_action_argument_option(action, :token, :allow_nil?, [true]),
-           :ok <- validate_action_option(action, :returns, [:boolean, Ash.Type.Boolean]) do
+      action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+      with :ok <-
+             action_validator.validate_action_argument_option(action, :jti, :allow_nil?, [true]),
+           :ok <-
+             action_validator.validate_action_argument_option(action, :token, :allow_nil?, [true]),
+           :ok <-
+             action_validator.validate_action_option(action, :returns, [
+               :boolean,
+               Ash.Type.Boolean
+             ]) do
         :ok
       else
         {:error, _} ->

--- a/lib/ash_authentication/transformer.ex
+++ b/lib/ash_authentication/transformer.ex
@@ -12,7 +12,6 @@ defmodule AshAuthentication.Transformer do
   alias Spark.{Dsl.Transformer, Error.DslError}
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
 
   @doc false
   @impl true
@@ -120,7 +119,9 @@ defmodule AshAuthentication.Transformer do
     do: String.to_atom("current_#{subject_name}")
 
   defp validate_read_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
          :ok <- validate_field_in_values(action, :type, [:read]) do
       :ok
     else

--- a/lib/ash_authentication/user_identity/transformer.ex
+++ b/lib/ash_authentication/user_identity/transformer.ex
@@ -11,7 +11,6 @@ defmodule AshAuthentication.UserIdentity.Transformer do
   alias Spark.{Dsl.Transformer, Error.DslError}
   import AshAuthentication.Utils
   import AshAuthentication.Validations
-  import AshAuthentication.Validations.Action
   import AshAuthentication.Validations.Attribute
 
   @doc false
@@ -261,20 +260,41 @@ defmodule AshAuthentication.UserIdentity.Transformer do
   end
 
   defp validate_upsert_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
-         :ok <- validate_action_argument_option(action, :user_info, :type, [:map, Type.Map]),
-         :ok <- validate_action_argument_option(action, :user_info, :allow_nil?, [false]),
-         :ok <- validate_action_argument_option(action, :oauth_tokens, :type, [:map, Type.Map]),
-         :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
-         :ok <- validate_action_has_change(action, UserIdentity.UpsertIdentityChange),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :user_info, :type, [
+             :map,
+             Type.Map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :user_info, :allow_nil?, [
+             false
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :type, [
+             :map,
+             Type.Map
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [
+             false
+           ]),
+         :ok <-
+           action_validator.validate_action_has_change(action, UserIdentity.UpsertIdentityChange),
          :ok <- validate_field_in_values(action, :type, [:create]),
          :ok <- validate_field_in_values(action, :upsert?, [true]),
          {:ok, user_id} <-
            UserIdentity.Info.user_identity_user_id_attribute_name(dsl_state),
          {:ok, user_resource} <- UserIdentity.Info.user_identity_user_resource(dsl_state),
          {:ok, user_resource_id} <- find_pk(user_resource),
-         :ok <- validate_action_argument_option(action, user_id, :type, [user_resource_id.type]),
-         :ok <- validate_action_argument_option(action, user_id, :allow_nil?, [false]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, user_id, :type, [
+             user_resource_id.type
+           ]),
+         :ok <-
+           action_validator.validate_action_argument_option(action, user_id, :allow_nil?, [false]),
          {:ok, uid} <- UserIdentity.Info.user_identity_uid_attribute_name(dsl_state),
          {:ok, strategy} <-
            UserIdentity.Info.user_identity_strategy_attribute_name(dsl_state),
@@ -305,7 +325,9 @@ defmodule AshAuthentication.UserIdentity.Transformer do
   end
 
   defp validate_destroy_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
          :ok <- validate_field_in_values(action, :type, [:destroy]),
          :ok <- validate_field_in_values(action, :primary?, [true]) do
       :ok
@@ -319,7 +341,9 @@ defmodule AshAuthentication.UserIdentity.Transformer do
   end
 
   defp validate_read_action(dsl_state, action_name) do
-    with {:ok, action} <- validate_action_exists(dsl_state, action_name),
+    action_validator = AshAuthentication.Info.authentication_action_validators!(dsl_state)
+
+    with {:ok, action} <- action_validator.validate_action_exists(dsl_state, action_name),
          :ok <- validate_field_in_values(action, :type, [:read]),
          :ok <- validate_field_in_values(action, :primary?, [true]) do
       :ok

--- a/lib/ash_authentication/validations/action.ex
+++ b/lib/ash_authentication/validations/action.ex
@@ -2,6 +2,8 @@ defmodule AshAuthentication.Validations.Action do
   @moduledoc """
   Validation helpers for Resource actions.
   """
+  @behaviour AshAuthentication.Validations.ActionValidators
+
   import AshAuthentication.Utils
   alias Ash.Resource.{Actions, Info}
   alias Spark.Error.DslError

--- a/lib/ash_authentication/validations/action_validators.ex
+++ b/lib/ash_authentication/validations/action_validators.ex
@@ -1,0 +1,57 @@
+defmodule AshAuthentication.Validations.ActionValidators do
+  @moduledoc """
+  Behaviour for action validation implementations.
+
+  This behaviour defines the callback interface for validating Ash Resource actions
+  in the context of AshAuthentication. Implementations of this behaviour can be
+  used to customize validation logic while maintaining the same interface.
+  """
+
+  alias Ash.Resource.Actions
+
+  @doc """
+  Validate that a named action actually exists.
+  """
+  @callback validate_action_exists(map, atom) ::
+              {:ok, Actions.action()} | {:error, Exception.t() | String.t()}
+
+  @doc """
+  Validate an action's argument has an option set to one of the provided values.
+  """
+  @callback validate_action_argument_option(Actions.action(), atom, atom, [any]) ::
+              :ok | {:error, Exception.t() | String.t()}
+
+  @doc """
+  Validate the presence of an argument on an action.
+  """
+  @callback validate_action_has_argument(Actions.action(), atom) :: :ok | {:error, Exception.t()}
+
+  @doc """
+  Validate the presence of the named change module on an action.
+  """
+  @callback validate_action_has_change(Actions.action(), module) ::
+              :ok | {:error, Exception.t()}
+
+  @doc """
+  Validate the presence of the named manual module on an action.
+  """
+  @callback validate_action_has_manual(Actions.action(), module) ::
+              :ok | {:error, Exception.t()}
+
+  @doc """
+  Validate the presence of the named validation module on an action.
+  """
+  @callback validate_action_has_validation(Actions.action(), module) ::
+              :ok | {:error, Exception.t()}
+
+  @doc """
+  Validate the presence of the named preparation module on an action.
+  """
+  @callback validate_action_has_preparation(Actions.action(), module) ::
+              :ok | {:error, Exception.t()}
+
+  @doc """
+  Validate the action has the provided option.
+  """
+  @callback validate_action_option(Actions.action(), atom, [any]) :: :ok | {:error, Exception.t()}
+end


### PR DESCRIPTION
This PR defines a behaviour `AshAuthentication.Validations.ActionValidators`, matching the implementation of `AshAuthentication.Validations.Action`,  and adds the `action_validators` DSL-field so that another validation module can be configured if needed, like this:

```
authentication do
  action_validators AshEvents.AshAuthenticationActionValidators
end
```

Furthermore, all previous direct usage of `AshAuthentication.Validations.Action` has been replaced by fetching and using the configured module.

The main reason for this PR is that other extensions (in this particular case, `ash_events`) might need to make modifications to an action's changes, and since `ash_authentication`'s verifiers that use `AshAuthentication.Validations.Action` expects to find the action changes in a specific way, the verifiers will fail even though the functionality of the added change remains intact.

Other extensions that manipulate an action in such a manner, can then define their own validators module to use with `ash_authentication`, that users can utilize if they are using both extensions in the same project.

This PR is 100% backwards-compatible and requires no effort from existing users of `ash_authentication`.