### PR TITLE
improve: ensure_get_by_action uses get_by

### DIFF
--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -485,13 +485,12 @@ if Code.ensure_loaded?(Igniter) do
         """
         read :get_by_#{options[:identity_field]} do
           description "Looks up a user by their #{options[:identity_field]}"
-          get? true
 
           argument :#{options[:identity_field]}, :ci_string do
             allow_nil? false
           end
 
-          filter expr(#{options[:identity_field]} == ^arg(:#{options[:identity_field]}))
+          get_by :#{options[:identity_field]}
         end
         """
       )

--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -485,11 +485,6 @@ if Code.ensure_loaded?(Igniter) do
         """
         read :get_by_#{options[:identity_field]} do
           description "Looks up a user by their #{options[:identity_field]}"
-
-          argument :#{options[:identity_field]}, :ci_string do
-            allow_nil? false
-          end
-
           get_by :#{options[:identity_field]}
         end
         """

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -246,11 +246,6 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       + |
       + |    read :get_by_email do
       + |      description("Looks up a user by their email")
-      + |
-      + |      argument :email, :ci_string do
-      + |        allow_nil?(false)
-      + |      end
-      + |
       + |      get_by :email
       + |    end
       + |

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -246,13 +246,12 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       + |
       + |    read :get_by_email do
       + |      description("Looks up a user by their email")
-      + |      get?(true)
       + |
       + |      argument :email, :ci_string do
       + |        allow_nil?(false)
       + |      end
       + |
-      + |      filter(expr(email == ^arg(:email)))
+      + |      get_by :email
       + |    end
       + |
       + |    update :reset_password_with_token do

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -246,7 +246,7 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       + |
       + |    read :get_by_email do
       + |      description("Looks up a user by their email")
-      + |      get_by :email
+      + |      get_by(:email)
       + |    end
       + |
       + |    update :reset_password_with_token do


### PR DESCRIPTION
I was going to fat-finger a pr to get `ensure_get_by_action` uses `get_by` instead of `get?` & `filter`. But the tests fail because the output is actually `get_by(:email)` instead of the expected `get_by :email` . 

First, is it intentional that `ensure_get_by_action` is set up the way it is? Or is there something wrong with my local setup that is generating that out?
<img width="1090" height="494" alt="CleanShot 2025-09-07 at 11 49 01@2x" src="https://github.com/user-attachments/assets/9c691b23-2d33-4928-9a4a-3473d5c310e1" />
