### PR TITLE
bugfix: Don't atomize keys for Apple strategy

### DIFF
--- a/lib/ash_authentication/strategies/apple/dsl.ex
+++ b/lib/ash_authentication/strategies/apple/dsl.ex
@@ -59,21 +59,11 @@ defmodule AshAuthentication.Strategy.Apple.Dsl do
       {:client_authentication_method, method} ->
         {:client_authentication_method, method}
 
-      {:openid_configuration, config} ->
-        {:openid_configuration, atomize_keys(config)}
-
       {key, value} ->
         {key, value}
     end)
     |> Keyword.put(:assent_strategy, strategy)
     |> Keyword.merge(params)
-  end
-
-  # sobelow_skip ["DOS.StringToAtom"]
-  defp atomize_keys(map) do
-    map
-    |> Enum.map(fn {key, value} -> {String.to_atom(key), value} end)
-    |> Enum.into(%{})
   end
 
   defp strategy_override_docs(strategy) do


### PR DESCRIPTION
Fixes error with Apple strategy: invalid map in :openid_configuration option: invalid value for map key: expected string, got: :authorization_endpoint
invalid value for :openid_configuration option: expected nil, got: %{authorization_endpoint: "https://appleid.apple.com/auth/authorize", issuer: "https://appleid.apple.com/", jwks_uri: "https://appleid.apple.com/auth/keys", token_endpoint: "https://appleid.apple.com/auth/token", token_endpoint_auth_methods_supported: ["client_secret_post"]}