### PR TITLE
fix: Add only existing sections into Ash.Resource

### DIFF
--- a/lib/mix/tasks/ash_authentication.install.ex
+++ b/lib/mix/tasks/ash_authentication.install.ex
@@ -91,7 +91,7 @@ if Code.ensure_loaded?(Igniter) do
       |> Igniter.Project.Config.configure("test.exs", :bcrypt_elixir, [:log_rounds], 1)
       |> Spark.Igniter.prepend_to_section_order(
         :"Ash.Resource",
-        [:authentication, :tokens]
+        [:authentication, :user_identity]
       )
       |> Igniter.compose_task(
         "ash.gen.domain",


### PR DESCRIPTION
Currently when running Igniter, it adds `:authentication` and `:tokens` under `Ash.Resource` in `config.exs`. The main issue is that `:tokens` do not seem to exist or have been moved under  `:authentication`. Also the documentation mentions another section called `:user_identity` but is not added by Igniter.

This PR removes the non-existing section `:tokens` and adds the missing section `:user_identity` in the config under `Ash.Resource`.

I just tried out `ash_authentication`, so I am not so familiar with it. Let me know if something is not correct.