### PR TITLE
fix: support :null atom from JOSE 1.11.11+ in JWT tenant validation

### DIFF
--- a/lib/ash_authentication/jwt.ex
+++ b/lib/ash_authentication/jwt.ex
@@ -6,7 +6,7 @@ defmodule AshAuthentication.Jwt do
   @default_algorithm "HS256"
   @default_lifetime_days 7
   @supported_algorithms Joken.Signer.algorithms()
-  import AshAuthentication.Utils, only: [to_sentence: 2]
+  import AshAuthentication.Utils, only: [to_sentence: 2, normalize_null: 1]
 
   @moduledoc """
   Uses the excellent `joken` hex package to generate and sign Json Web Tokens.
@@ -203,7 +203,7 @@ defmodule AshAuthentication.Jwt do
          {:ok, claims} <- Joken.verify(token, signer),
          defaults <- Config.default_claims(resource, opts),
          {:ok, claims} <- Joken.validate(defaults, claims, resource) do
-      {:ok, claims, resource}
+      {:ok, normalize_null(claims), resource}
     else
       _ -> :error
     end
@@ -215,7 +215,7 @@ defmodule AshAuthentication.Jwt do
          {:ok, claims} <- Joken.verify(token, signer),
          defaults <- Config.default_claims(resource, opts),
          {:ok, claims} <- Joken.validate(defaults, claims, resource) do
-      {:ok, claims, resource}
+      {:ok, normalize_null(claims), resource}
     else
       _ -> :error
     end

--- a/lib/ash_authentication/jwt/config.ex
+++ b/lib/ash_authentication/jwt/config.ex
@@ -101,11 +101,7 @@ defmodule AshAuthentication.Jwt.Config do
   Validate that the "tenant" claim matches the provided tenant option.
   """
   @spec validate_tenant(nil | :null | String.t(), nil | String.t()) :: boolean()
-  def validate_tenant(maybe_tenant, tenant), do: normalize_null(maybe_tenant) == tenant
-
-  # To support JOSE 1.11.11+ and Erlang's built-in JSON module, it sends :null instead of nil.
-  defp normalize_null(:null), do: nil
-  defp normalize_null(value), do: value
+  def validate_tenant(maybe_tenant, tenant), do: Utils.normalize_null(maybe_tenant) == tenant
 
   @doc """
   The validation function used to validate the "aud" claim.

--- a/lib/ash_authentication/utils.ex
+++ b/lib/ash_authentication/utils.ex
@@ -291,4 +291,17 @@ defmodule AshAuthentication.Utils do
   def lifetime_to_seconds({minutes, :minutes}), do: minutes * 60
   def lifetime_to_seconds({hours, :hours}), do: hours * 60 * 60
   def lifetime_to_seconds({days, :days}), do: days * 60 * 60 * 24
+
+  @doc """
+  Normalize claim tenant :null atom to nil.
+
+  > To support JOSE 1.11.11+ and Erlang's built-in JSON module, it sends :null instead of nil.
+  """
+  @spec normalize_null(term()) :: term()
+  def normalize_null(:null), do: nil
+
+  def normalize_null(map) when is_map(map),
+    do: Map.new(map, fn {k, v} -> {k, normalize_null(v)} end)
+
+  def normalize_null(value), do: value
 end


### PR DESCRIPTION
`JOSE` 1.11.11+ changed how nil values are handled when using Erlang/OTP 27+'s built-in json module.
JSON null is now decoded as the :null atom instead of Elixir's nil, causing tenant claim validation to fail for master/global tokens (where tenant is nil). 
This results in 403 Forbidden errors for users with nil tenant (for example site_id nil). 

This fix `normalizes :null` to nil before comparison to support both old and new JOSE versions.

> Handles both `nil` and `:null` atom values to support JOSE 1.11.11+ which decodes JSON `null` as the `:null` atom when using Erlang's built-in json module.


Diff: https://diff.hex.pm/diff/jose/1.11.10..1.11.11

> All tests passed in my project and `ash_authentication`, and i tested it in 2 version, the current and elixir 1.19 otp 28

Thank you in advance