### PR TITLE
Refactor build_redirect_uri to pattern match URI struct

### DIFF
--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -252,7 +252,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
   defp build_redirect_uri(strategy, context) do
     with {:ok, subject_name} <- Info.authentication_subject_name(strategy.resource),
          {:ok, redirect_uri} <- fetch_secret(strategy, :redirect_uri, context),
-         {:ok, uri} <- URI.new(redirect_uri) do
+         {:ok, %URI{} = uri} <- URI.new(redirect_uri) do
       suffix = Path.join([to_string(subject_name), to_string(strategy.name), "callback"])
       # Don't append the path if the secret ends with the path already
       path =


### PR DESCRIPTION
Silences the following compiler warning:
```
     warning: a struct for URI is expected on struct update:

         %URI{uri | path: path}

     but got type:

         dynamic()

     where "uri" was given the type:

         # type: dynamic()
         # from: lib/ash_authentication/strategies/oauth2/plug.ex:255:21
         {:ok, uri} <- URI.new(redirect_uri)

     when defining the variable "uri", you must also pattern match on "%URI{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 265 │       {:ok, to_string(%URI{uri | path: path})}
     │                       ~
     │
     └─ (ash_authentication 4.13.3) lib/ash_authentication/strategies/oauth2/plug.ex:265:23: AshAuthentication.Strategy.OAuth2.Plug.build_redirect_uri/2

Generated ash_authentication app
```