### PR TITLE
fix: Add an argument to the generated `get_by_<identity>` field that is `allow_nil?: false`

### DIFF
--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -515,6 +515,10 @@ if Code.ensure_loaded?(Igniter) do
         read :get_by_#{options[:identity_field]} do
           description "Looks up a user by their #{options[:identity_field]}"
           get_by :#{options[:identity_field]}
+
+          argument :#{options[:identity_field]}, :ci_string do
+            allow_nil? false
+          end
         end
         """
       )

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -251,6 +251,10 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       + |    read :get_by_email do
       + |      description("Looks up a user by their email")
       + |      get_by(:email)
+      + |
+      + |      argument :email, :ci_string do
+      + |        allow_nil?(false)
+      + |      end
       + |    end
       + |
       + |    update :reset_password_with_token do


### PR DESCRIPTION
This resolves a warning generated by the MagicLink strategy verifier

Closes #1102