### PR TITLE
fix: skip remember_me token generation when AAP handles it via redirect

### DIFF
--- a/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
+++ b/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
@@ -38,14 +38,20 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation do
   @impl true
   @spec prepare(Query.t(), keyword, Preparation.Context.t()) :: Query.t()
   def prepare(query, options, context) do
-    remember_me_argument = Keyword.get(options, :argument, :remember_me)
+    # Skip token generation if the caller will handle remember_me via redirect
+    # (e.g. AshAuthentication.Phoenix with sign_in_tokens_enabled?)
+    if query.context[:private][:skip_remember_me_token_generation] do
+      query
+    else
+      remember_me_argument = Keyword.get(options, :argument, :remember_me)
 
-    case Query.get_argument(query, remember_me_argument) do
-      true ->
-        prepare_after_action(query, options, context)
+      case Query.get_argument(query, remember_me_argument) do
+        true ->
+          prepare_after_action(query, options, context)
 
-      _ ->
-        query
+        _ ->
+          query
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds support for a `skip_remember_me_token_generation` context flag in `MaybeGenerateTokenPreparation`
- When this flag is set in `query.context[:private]`, the preparation skips token generation

## Problem

When AshAuthentication.Phoenix uses `sign_in_tokens_enabled?`, it:
1. Submits the sign_in form (which triggers `MaybeGenerateTokenPreparation`)
2. Redirects to `sign_in_with_token` with `remember_me=true` as a query param
3. The token is then generated in the `sign_in_with_token` action

The token generated in step 1 is never used but still gets stored in the database. For users with token storage (especially multi-region setups), this creates unnecessary database writes.

## Solution

Allow callers to set a context flag to suppress token generation when they'll handle remember_me themselves via redirect.

## Test plan

- [x] All existing tests pass
- [x] Companion PR in ash_authentication_phoenix sets the flag

Fixes #1118