### PR TITLE
fix: add `token` to Phoenix filter_parameters during installation

### DIFF
--- a/lib/mix/tasks/ash_authentication.install.ex
+++ b/lib/mix/tasks/ash_authentication.install.ex
@@ -93,6 +93,7 @@ if Code.ensure_loaded?(Igniter) do
       |> Igniter.Project.Formatter.import_dep(:ash_authentication)
       |> Igniter.Project.Formatter.add_formatter_plugin(Spark.Formatter)
       |> Igniter.Project.Config.configure("test.exs", :bcrypt_elixir, [:log_rounds], 1)
+      |> configure_filter_parameters()
       |> Spark.Igniter.prepend_to_section_order(
         :"Ash.Resource",
         [:authentication, :token, :user_identity]
@@ -495,6 +496,26 @@ if Code.ensure_loaded?(Igniter) do
           value
         end
       end)
+    end
+
+    defp configure_filter_parameters(igniter) do
+      web_module = Igniter.Libs.Phoenix.web_module(igniter)
+      {web_module_exists?, igniter} = Igniter.Project.Module.module_exists(igniter, web_module)
+
+      if web_module_exists? do
+        Igniter.Project.Config.configure(
+          igniter,
+          "config.exs",
+          :phoenix,
+          [:filter_parameters],
+          ["password", "token"],
+          updater: fn zipper ->
+            Igniter.Code.List.append_new_to_list(zipper, "token")
+          end
+        )
+      else
+        igniter
+      end
     end
   end
 else

--- a/test/mix/tasks/ash_authentication.install_test.exs
+++ b/test/mix/tasks/ash_authentication.install_test.exs
@@ -307,4 +307,32 @@ defmodule Mix.Tasks.AshAuthentication.InstallTest do
     end
     """)
   end
+
+  test "installation does not add filter_parameters without Phoenix", %{igniter: igniter} do
+    diff = diff(igniter)
+    refute diff =~ "filter_parameters"
+  end
+
+  describe "with Phoenix" do
+    setup do
+      igniter =
+        test_project()
+        |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+        |> Igniter.create_new_file("lib/test_web.ex", """
+        defmodule TestWeb do
+        end
+        """)
+        |> apply_igniter!()
+        |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+        |> Igniter.Project.Formatter.remove_formatter_plugin(Spark.Formatter)
+
+      [igniter: igniter]
+    end
+
+    test "installation adds token to filter_parameters", %{igniter: igniter} do
+      diff = diff(igniter)
+      assert diff =~ "filter_parameters"
+      assert diff =~ ~s|["password", "token"]|
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `config :phoenix, :filter_parameters, ["password", "token"]` during Igniter installation when a Phoenix web module is detected
- Prevents magic link tokens from being logged in plain text in Phoenix request logs

## Test plan

- [x] Added test verifying filter_parameters is added when Phoenix web module exists
- [x] Added test verifying filter_parameters is NOT added when no Phoenix web module exists
- [x] All existing installer tests pass

Closes https://github.com/team-alembic/ash_authentication_phoenix/issues/534