### PR TITLE
fix: preserve existing context when adding request context

### DIFF
--- a/lib/ash_authentication/plug/dispatcher.ex
+++ b/lib/ash_authentication/plug/dispatcher.ex
@@ -75,18 +75,18 @@ defmodule AshAuthentication.Plug.Dispatcher do
   defp add_request_context(conn) do
     peer_data = Conn.get_peer_data(conn)
 
-    context =
-      %{
-        ash_authentication_request: %{
-          remote_ip: peer_data.address |> :inet.ntoa() |> to_string(),
-          remote_port: peer_data.port,
-          http_host: conn.host,
-          http_method: conn.method,
-          forwarded: Conn.get_req_header(conn, "forwarded"),
-          x_forwarded_for: Conn.get_req_header(conn, "x-forwarded-for")
-        }
+    request_context = %{
+      ash_authentication_request: %{
+        remote_ip: peer_data.address |> :inet.ntoa() |> to_string(),
+        remote_port: peer_data.port,
+        http_host: conn.host,
+        http_method: conn.method,
+        forwarded: Conn.get_req_header(conn, "forwarded"),
+        x_forwarded_for: Conn.get_req_header(conn, "x-forwarded-for")
       }
+    }
 
-    Ash.PlugHelpers.set_context(conn, context)
+    existing_context = Ash.PlugHelpers.get_context(conn) || %{}
+    Ash.PlugHelpers.set_context(conn, Map.merge(existing_context, request_context))
   end
 end


### PR DESCRIPTION
## Summary

- Merge request context with existing context instead of replacing it
- Fixes regression introduced in v4.12 where shared context set by earlier plugs was lost

The `add_request_context/1` function was calling `Ash.PlugHelpers.set_context/2` which replaces the entire context. This caused any context set by the user's plugs (e.g., for tracking IP/user-agent in custom actions) to be overwritten.

Now retrieves any existing context first and merges it with the request metadata.

Fixes #1085

## Test plan

- [x] All CI checks pass locally
- [ ] User can verify their shared context is preserved through auth actions