### PR TITLE
fix: return `{:error, AuthenticationFailed.t}` from `Jwt.token_for_user/2`

### DIFF
--- a/lib/ash_authentication/add_ons/confirmation.ex
+++ b/lib/ash_authentication/add_ons/confirmation.ex
@@ -159,7 +159,7 @@ defmodule AshAuthentication.AddOn.Confirmation do
           Resource.record(),
           opts :: Keyword.t()
         ) ::
-          {:ok, String.t()} | :error | {:error, any}
+          {:ok, String.t()} | {:error, any}
   def confirmation_token(strategy, changeset, user, opts \\ []) do
     claims = %{"act" => strategy.confirm_action_name}
 

--- a/lib/ash_authentication/strategies/magic_link.ex
+++ b/lib/ash_authentication/strategies/magic_link.ex
@@ -171,7 +171,7 @@ defmodule AshAuthentication.Strategy.MagicLink do
   Used by `AshAuthentication.Strategy.MagicLink.RequestPreparation`.
   """
   @spec request_token_for(t, Resource.record(), opts :: Keyword.t(), context :: map()) ::
-          {:ok, binary} | :error
+          {:ok, binary} | {:error, AshAuthentication.Errors.AuthenticationFailed.t()}
   def request_token_for(strategy, user, opts \\ [], context \\ %{})
       when is_struct(strategy, __MODULE__) and is_struct(user, strategy.resource) do
     case Jwt.token_for_user(
@@ -187,7 +187,7 @@ defmodule AshAuthentication.Strategy.MagicLink do
            context
          ) do
       {:ok, token, _claims} -> {:ok, token}
-      :error -> :error
+      {:error, error} -> {:error, error}
     end
   end
 
@@ -196,6 +196,8 @@ defmodule AshAuthentication.Strategy.MagicLink do
 
   Used by `AshAuthentication.Strategy.MagicLink.RequestPreparation`.
   """
+  @spec request_token_for_identity(t, term(), opts :: Keyword.t(), context :: map()) ::
+          {:ok, binary} | {:error, AshAuthentication.Errors.AuthenticationFailed.t()}
   def request_token_for_identity(strategy, identity, opts \\ [], context \\ %{})
       when is_struct(strategy, __MODULE__) do
     case Jwt.token_for_resource(
@@ -208,7 +210,7 @@ defmodule AshAuthentication.Strategy.MagicLink do
            context
          ) do
       {:ok, token, _claims} -> {:ok, token}
-      :error -> :error
+      {:error, error} -> {:error, error}
     end
   end
 end

--- a/lib/ash_authentication/strategies/password/request_password_reset.ex
+++ b/lib/ash_authentication/strategies/password/request_password_reset.ex
@@ -53,12 +53,6 @@ defmodule AshAuthentication.Strategy.Password.RequestPasswordReset do
         {:ok, nil} ->
           :ok
 
-        :error ->
-          Logger.warning("""
-          Something went wrong generating a token during password reset
-          for: #{inspect(action_input.resource)} `#{identity}`
-          """)
-
         {:error, error} ->
           Logger.warning("""
           Something went wrong resetting password for #{inspect(action_input.resource)} `#{identity}`

--- a/lib/ash_authentication/strategies/password/sign_in_with_token_preparation.ex
+++ b/lib/ash_authentication/strategies/password/sign_in_with_token_preparation.ex
@@ -97,7 +97,7 @@ defmodule AshAuthentication.Strategy.Password.SignInWithTokenPreparation do
     too_many_users_returned(query, strategy)
   end
 
-  defp verify_result(query, [user], strategy, context) do
+  defp verify_result(query, [user], _strategy, context) do
     extra_claims = query.context[:extra_token_claims] || %{}
 
     claims =
@@ -110,18 +110,8 @@ defmodule AshAuthentication.Strategy.Password.SignInWithTokenPreparation do
       {:ok, token, _claims} ->
         {:ok, [Resource.put_metadata(user, :token, token)]}
 
-      :error ->
-        {:error,
-         AuthenticationFailed.exception(
-           strategy: strategy,
-           query: query,
-           caused_by: %{
-             module: __MODULE__,
-             action: query.action,
-             resource: query.resource,
-             message: "Unable to generate token for user"
-           }
-         )}
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/ash_authentication/strategies/remember_me/maybe_generate_token_change.ex
+++ b/lib/ash_authentication/strategies/remember_me/maybe_generate_token_change.ex
@@ -31,7 +31,7 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenChange do
   """
   use Ash.Resource.Change
   alias Ash.Resource
-  alias AshAuthentication.{Errors.AuthenticationFailed, Info, Jwt, Utils}
+  alias AshAuthentication.{Info, Jwt, Utils}
 
   @impl true
   def change(changeset, options, context) do
@@ -90,18 +90,8 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenChange do
 
         {:ok, user_with_meta}
 
-      :error ->
-        {:error,
-         AuthenticationFailed.exception(
-           strategy: strategy,
-           query: nil,
-           caused_by: %{
-             module: __MODULE__,
-             action: changeset.action,
-             resource: changeset.resource,
-             message: "Unable to generate remember me token"
-           }
-         )}
+      {:error, error} ->
+        {:error, error}
     end
   end
 end

--- a/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
+++ b/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
@@ -31,7 +31,7 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation do
   """
   use Ash.Resource.Preparation
   alias Ash.{Query, Resource, Resource.Preparation}
-  alias AshAuthentication.{Errors.AuthenticationFailed, Info, Jwt, Utils}
+  alias AshAuthentication.{Info, Jwt, Utils}
 
   @doc false
   @impl true
@@ -100,18 +100,8 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation do
 
         {:ok, [user]}
 
-      :error ->
-        {:error,
-         AuthenticationFailed.exception(
-           strategy: strategy,
-           query: query,
-           caused_by: %{
-             module: __MODULE__,
-             action: query.action,
-             resource: query.resource,
-             message: "Unable to generate remember me token"
-           }
-         )}
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/ash_authentication/strategies/remember_me/sign_in_preparation.ex
+++ b/lib/ash_authentication/strategies/remember_me/sign_in_preparation.ex
@@ -69,7 +69,7 @@ defmodule AshAuthentication.Strategy.RememberMe.SignInPreparation do
     end
   end
 
-  defp verify_result(query, [user], strategy, context) do
+  defp verify_result(query, [user], _strategy, context) do
     extra_claims = query.context[:extra_token_claims] || %{}
 
     claims =
@@ -82,18 +82,8 @@ defmodule AshAuthentication.Strategy.RememberMe.SignInPreparation do
       {:ok, token, _claims} ->
         {:ok, [Resource.put_metadata(user, :token, token)]}
 
-      :error ->
-        {:error,
-         AuthenticationFailed.exception(
-           strategy: strategy,
-           query: query,
-           caused_by: %{
-             module: __MODULE__,
-             action: query.action,
-             resource: query.resource,
-             message: "Unable to generate token for user"
-           }
-         )}
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -176,7 +176,8 @@ defmodule DataCase do
   end
 
   @doc "Generate a remember me token for a user"
-  @spec generate_remember_me_token(Example.UserWithRememberMe.t()) :: {:ok, String.t()} | :error
+  @spec generate_remember_me_token(Example.UserWithRememberMe.t()) ::
+          {:ok, String.t()} | {:error, any()}
   def generate_remember_me_token(user) do
     claims = %{"purpose" => "remember_me"}
 
@@ -187,7 +188,7 @@ defmodule DataCase do
 
     case AshAuthentication.Jwt.token_for_user(user, claims, opts) do
       {:ok, token, _claims} -> {:ok, token}
-      :error -> :error
+      {:error, error} -> {:error, error}
     end
   end
 


### PR DESCRIPTION
## Summary

- Change `Jwt.token_for_user/2` and `Jwt.token_for_resource/4` to return `{:error, AuthenticationFailed.t()}` instead of bare `:error`
- Preserves diagnostic information in `caused_by` while keeping the user-facing message safe
- Updates all callsites throughout the codebase to handle the new error format
- Refactors several functions to reduce nesting and cyclomatic complexity (credo compliance)

## Breaking Change

External callers of `Jwt.token_for_user/2` will need to update their error handling:

```elixir
# Before
case Jwt.token_for_user(user) do
  {:ok, token, claims} -> # handle success
  :error -> # handle error
end

# After
case Jwt.token_for_user(user) do
  {:ok, token, claims} -> # handle success
  {:error, error} -> # handle error - error contains diagnostic info
end
```

## Test plan

- [x] All existing tests pass (425 tests, 0 failures)
- [x] Dialyzer passes with no errors
- [x] Credo passes with no issues
- [x] Full `mix check --no-retry` passes

Closes #1094