### PR TITLE
feat!: convert request actions from read to generic action

### DIFF
--- a/lib/ash_authentication/strategies/magic_link/actions.ex
+++ b/lib/ash_authentication/strategies/magic_link/actions.ex
@@ -19,36 +19,20 @@ defmodule AshAuthentication.Strategy.MagicLink.Actions do
   """
   @spec request(MagicLink.t(), map, keyword) :: :ok | {:error, any}
   def request(strategy, params, options) do
-    action = Ash.Resource.Info.action(strategy.resource, strategy.request_action_name)
-
     options =
       options
       |> Keyword.put_new_lazy(:domain, fn ->
         Info.domain!(strategy.resource)
       end)
 
-    case action.type do
-      :read ->
-        strategy.resource
-        |> Query.new()
-        |> Query.set_context(%{private: %{ash_authentication?: true}})
-        |> Query.for_read(strategy.request_action_name, params, options)
-        |> Ash.read()
-        |> case do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
-
-      :action ->
-        strategy.resource
-        |> ActionInput.new()
-        |> ActionInput.set_context(%{private: %{ash_authentication?: true}})
-        |> ActionInput.for_action(strategy.request_action_name, params, options)
-        |> Ash.run_action()
-        |> case do
-          :ok -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+    strategy.resource
+    |> ActionInput.new()
+    |> ActionInput.set_context(%{private: %{ash_authentication?: true}})
+    |> ActionInput.for_action(strategy.request_action_name, params, options)
+    |> Ash.run_action()
+    |> case do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/ash_authentication/strategies/password/actions.ex
+++ b/lib/ash_authentication/strategies/password/actions.ex
@@ -234,26 +234,11 @@ defmodule AshAuthentication.Strategy.Password.Actions do
          ) do
       nil ->
         {:error,
-         NoSuchAction.exception(resource: strategy.resource, action: :reset_request, type: :read)}
-
-      %{type: :read, name: action_name} ->
-        options =
-          options
-          |> Keyword.put_new_lazy(:domain, fn -> Info.domain!(strategy.resource) end)
-
-        strategy.resource
-        |> Query.new()
-        |> Query.set_context(%{
-          private: %{
-            ash_authentication?: true
-          }
-        })
-        |> Query.for_read(action_name, params, options)
-        |> Ash.read()
-        |> case do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+         NoSuchAction.exception(
+           resource: strategy.resource,
+           action: :reset_request,
+           type: :action
+         )}
 
       %{type: :action, name: action_name} ->
         options =
@@ -280,7 +265,7 @@ defmodule AshAuthentication.Strategy.Password.Actions do
   def reset_request(%Password{} = strategy, _params, _options),
     do:
       {:error,
-       NoSuchAction.exception(resource: strategy.resource, action: :reset_request, type: :read)}
+       NoSuchAction.exception(resource: strategy.resource, action: :reset_request, type: :action)}
 
   @doc """
   Attempt to change a user's password using a reset token.

--- a/test/ash_authentication/strategies/password/actions_test.exs
+++ b/test/ash_authentication/strategies/password/actions_test.exs
@@ -212,22 +212,20 @@ defmodule AshAuthentication.Strategy.Password.ActionsTest do
       log =
         capture_log(fn ->
           params = %{"username" => user.username}
-          options = []
           resettable = strategy.resettable
 
           result =
             strategy.resource
-            |> Ash.Query.new()
-            |> Ash.Query.set_context(%{
+            |> Ash.ActionInput.new()
+            |> Ash.ActionInput.set_context(%{
               private: %{
                 ash_authentication?: true
               }
             })
-            |> Ash.Query.for_read(resettable.request_password_reset_action_name, params)
-            |> Ash.Query.select([])
-            |> Ash.read(options)
+            |> Ash.ActionInput.for_action(resettable.request_password_reset_action_name, params)
+            |> Ash.run_action()
             |> case do
-              {:ok, _} -> :ok
+              :ok -> :ok
               {:error, reason} -> {:error, reason}
             end
 


### PR DESCRIPTION
## Summary

- Converts password reset request and magic link request actions from `:read` to `:action` type
- Auto-generates `get_by_<identity_field>` read actions for user lookup
- Adds upgrade function for 5.0.0 to help migrate custom actions

**BREAKING CHANGE**: Users with custom `:read` request actions must migrate to `:action` type.

## Test plan

- [x] All existing tests pass
- [x] `mix check --no-retry` passes (compiler, credo, dialyzer, doctor, formatter, sobelow, tests)
- [ ] Manual testing of password reset flow
- [ ] Manual testing of magic link flow

Closes #837