### PR TITLE
improvement: add `remember_me` to password sign-in strategy by default

### DIFF
--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -959,8 +959,17 @@ if Code.ensure_loaded?(Igniter) do
           sensitive? true
         end
 
+        argument :remember_me, :boolean do
+          description "Whether to generate a remember me token"
+          allow_nil? true
+        end
+
         # validates the provided #{options[:identity_field]} and password and generates a token
         prepare AshAuthentication.Strategy.Password.SignInPreparation
+
+        # generates a remember me token if the remember_me argument is true
+        prepare {AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation,
+                strategy_name: :remember_me}
 
         metadata :token, :string do
           description "A JWT that can be used to authenticate the user."

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -171,8 +171,19 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       + |        sensitive?(true)
       + |      end
       + |
+      + |      argument :remember_me, :boolean do
+      + |        description("Whether to generate a remember me token")
+      + |        allow_nil?(true)
+      + |      end
+      + |
       + |      # validates the provided email and password and generates a token
       + |      prepare(AshAuthentication.Strategy.Password.SignInPreparation)
+      + |
+      + |      # generates a remember me token if the remember_me argument is true
+      + |      prepare(
+      + |        {AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation,
+      + |         strategy_name: :remember_me}
+      + |      )
       + |
       + |      metadata :token, :string do
       + |        description("A JWT that can be used to authenticate the user.")


### PR DESCRIPTION
remember_me was configured, but wasn't being shown in forms on new applications because the argument/change wasn't there on the action.