### PR TITLE
improvement: move Phoenix concerns out of AA igniters

### DIFF
--- a/documentation/topics/upgrading.md
+++ b/documentation/topics/upgrading.md
@@ -103,7 +103,7 @@ The igniter tasks for password, magic_link, TOTP, and confirmation strategies no
 
 If you use `ash_authentication_phoenix`, its new convention-named strategy tasks (`ash_authentication_phoenix.add_strategy.password`, etc.) handle the Phoenix integration automatically — upgrading senders to use Swoosh and verified routes, modifying the AuthController for TOTP 2FA, and inserting TOTP routes.
 
-**Action required:** If you re-run the igniter installer, the Phoenix-specific sender code will now come from AAP's tasks. Existing senders in your project are not affected — the igniter only modifies files it creates, and uses `on_exists: :overwrite` for sender modules.
+**Action required:** If you re-run the igniter installer, the Phoenix-specific sender code will now come from AAP's tasks. Existing senders in your project are not affected — the igniter uses `on_exists: :warning` for sender modules, so existing customisations are preserved.
 
 ### New Features
 

--- a/documentation/topics/upgrading.md
+++ b/documentation/topics/upgrading.md
@@ -95,11 +95,29 @@ user_info["email_verified"] == "true"
 user_info["email_verified"] == true
 ```
 
+### Igniter Task Changes
+
+#### Phoenix-specific code moved to ash_authentication_phoenix
+
+The igniter tasks for password, magic_link, TOTP, and confirmation strategies no longer generate Phoenix-specific code (Swoosh senders with verified routes, controller modifications). AA's tasks now generate only resource-level code with basic `IO.puts` senders.
+
+If you use `ash_authentication_phoenix`, its new convention-named strategy tasks (`ash_authentication_phoenix.add_strategy.password`, etc.) handle the Phoenix integration automatically — upgrading senders to use Swoosh and verified routes, modifying the AuthController for TOTP 2FA, and inserting TOTP routes.
+
+**Action required:** If you re-run the igniter installer, the Phoenix-specific sender code will now come from AAP's tasks. Existing senders in your project are not affected — the igniter only modifies files it creates, and uses `on_exists: :overwrite` for sender modules.
+
 ### New Features
 
 #### TOTP Two-Factor Authentication
 
 Version 5.0.0 adds a complete TOTP (Time-based One-Time Password) strategy for two-factor authentication. See the [TOTP tutorial](/documentation/tutorials/totp.md) for setup instructions.
+
+To add TOTP to an existing project with `ash_authentication_phoenix`:
+
+```bash
+mix ash_authentication_phoenix.add_strategy totp
+```
+
+This composes both the AA resource-level task and the AAP Phoenix integration task.
 
 #### Extra JWT Claims
 

--- a/lib/ash_authentication/add_ons/audit_log/auditor.ex
+++ b/lib/ash_authentication/add_ons/audit_log/auditor.ex
@@ -193,6 +193,7 @@ defmodule AshAuthentication.AddOn.AuditLog.Auditor do
 
     context
     |> Map.take([:actor, :tenant])
+    |> Map.update(:actor, nil, &serialise_actor/1)
     |> Map.put(:request, processed_request)
     |> Map.put(:params, get_params(input, audit_strategy))
   end
@@ -225,4 +226,14 @@ defmodule AshAuthentication.AddOn.AuditLog.Auditor do
     do: Map.new(attribute_names, &{&1, Ash.Changeset.get_attribute(input, &1)})
 
   defp get_named_attributes(_input, _attribute_names), do: %{}
+
+  defp serialise_actor(nil), do: nil
+
+  defp serialise_actor(actor) when is_struct(actor) do
+    AshAuthentication.user_to_subject(actor)
+  rescue
+    _ -> inspect(actor)
+  end
+
+  defp serialise_actor(actor), do: actor
 end

--- a/lib/ash_authentication/igniter.ex
+++ b/lib/ash_authentication/igniter.ex
@@ -324,24 +324,6 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     @doc """
-    Checks for a Phoenix web module and returns a `use` line for verified routes.
-
-    Returns `{web_module_exists?, use_line_or_nil, igniter}`.
-    """
-    @spec web_module_use_line(Igniter.t()) :: {boolean(), String.t() | nil, Igniter.t()}
-    def web_module_use_line(igniter) do
-      web_module = Igniter.Libs.Phoenix.web_module(igniter)
-      {web_module_exists?, igniter} = Igniter.Project.Module.module_exists(igniter, web_module)
-
-      use_web_module =
-        if web_module_exists? do
-          "use #{inspect(web_module)}, :verified_routes"
-        end
-
-      {web_module_exists?, use_web_module, igniter}
-    end
-
-    @doc """
     Returns the parent module of a given module.
 
     Useful for deriving a domain module from a resource module.

--- a/lib/ash_authentication/strategies/totp/plug.ex
+++ b/lib/ash_authentication/strategies/totp/plug.ex
@@ -54,7 +54,7 @@ defmodule AshAuthentication.Strategy.Totp.Plug do
   @spec verify(Conn.t(), Totp.t()) :: Conn.t()
   def verify(conn, strategy) do
     user = get_actor(conn)
-    params = subject_params(conn, strategy) |> Map.put("user", user)
+    params = subject_params(conn, strategy) |> Map.take(["code"]) |> Map.put("user", user)
     opts = opts(conn)
     result = Strategy.action(strategy, :verify, params, opts)
 

--- a/lib/ash_authentication/strategies/totp/transformer.ex
+++ b/lib/ash_authentication/strategies/totp/transformer.ex
@@ -532,6 +532,7 @@ defmodule AshAuthentication.Strategy.Totp.Transformer do
         name: :user,
         type: Ash.Type.Struct,
         allow_nil?: false,
+        sensitive?: true,
         description: "The user whose code to check.",
         constraints: [instance_of: module]
       ),

--- a/lib/mix/tasks/ash_authentication.add_add_on.confirmation.ex
+++ b/lib/mix/tasks/ash_authentication.add_add_on.confirmation.ex
@@ -95,7 +95,7 @@ if Code.ensure_loaded?(Igniter) do
         :password,
         """
         confirmation :confirm_new_user do
-          monitor_fields [:#{options[:identity_field]}]
+          monitor_fields [#{inspect(options[:identity_field])}]
           confirm_on_create? true
           confirm_on_update? false
           require_interaction? true
@@ -130,7 +130,8 @@ if Code.ensure_loaded?(Igniter) do
           /confirm_new_user/\#{token}
           """)
         end
-        '''
+        ''',
+        on_exists: :warning
       )
     end
   end

--- a/lib/mix/tasks/ash_authentication.add_add_on.confirmation.ex
+++ b/lib/mix/tasks/ash_authentication.add_add_on.confirmation.ex
@@ -111,78 +111,7 @@ if Code.ensure_loaded?(Igniter) do
       |> create_new_user_confirmation_sender(sender, options)
     end
 
-    defp create_new_user_confirmation_sender(igniter, sender, options) do
-      case Igniter.Libs.Swoosh.list_mailers(igniter) do
-        {igniter, [mailer]} ->
-          {_web_module_exists?, use_web_module, igniter} =
-            AshAuthentication.Igniter.web_module_use_line(igniter)
-
-          Igniter.Project.Module.create_module(
-            igniter,
-            sender,
-            ~s'''
-            @moduledoc """
-            Sends an email for a new user to confirm their email address.
-            """
-
-            use AshAuthentication.Sender
-            #{use_web_module}
-
-            import Swoosh.Email
-
-            alias #{inspect(mailer)}
-
-            @impl true
-            def send(user, token, _) do
-              new()
-              # TODO: Replace with your email
-              |> from({"noreply", "noreply@example.com"})
-              |> to(to_string(user.email))
-              |> subject("Confirm your email address")
-              |> html_body(body([token: token]))
-              |> #{List.last(Module.split(mailer))}.deliver!()
-            end
-
-            defp body(params) do
-              url = url(~p"/confirm_new_user/\#{params[:token]}")
-
-              """
-              <p>Click this link to confirm your email:</p>
-              <p><a href="\#{url}">\#{url}</a></p>
-              """
-            end
-            '''
-          )
-
-        _ ->
-          create_example_new_user_confirmation_sender(igniter, sender, options)
-      end
-    end
-
-    defp create_example_new_user_confirmation_sender(igniter, sender, options) do
-      {web_module_exists?, use_web_module, igniter} =
-        AshAuthentication.Igniter.web_module_use_line(igniter)
-
-      example_domain = AshAuthentication.Igniter.parent_module(options[:user])
-
-      real_example =
-        if web_module_exists? do
-          """
-          # Example of how you might send this email
-          # #{inspect(example_domain)}.Emails.send_new_user_confirmation_email(
-          #   user,
-          #   token
-          # )
-          """
-        end
-
-      url =
-        if use_web_module do
-          "\#{url(~p\"/confirm_new_user?/\#{token}\")}"
-        else
-          "/confirm_new_user/\#{token}"
-        end
-
+    defp create_new_user_confirmation_sender(igniter, sender, _options) do
       Igniter.Project.Module.create_module(
         igniter,
         sender,
@@ -192,15 +121,13 @@ if Code.ensure_loaded?(Igniter) do
         """
 
         use AshAuthentication.Sender
-        #{use_web_module}
 
         @impl true
         def send(_user, token, _) do
-          #{real_example}
           IO.puts("""
           Click this link to confirm your email:
 
-          #{url}
+          /confirm_new_user/\#{token}
           """)
         end
         '''

--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -14,7 +14,8 @@ if Code.ensure_loaded?(Igniter) do
     @strategies [
       password: "Register and sign in with a username/email and a password.",
       magic_link: "Register and sign in with a magic link, sent via email to the user.",
-      api_key: "Sign in with an API key."
+      api_key: "Sign in with an API key.",
+      totp: "Authenticate with a time-based one-time password (TOTP)."
     ]
 
     @strategy_explanation Enum.map_join(@strategies, "\n", fn {name, description} ->
@@ -26,7 +27,8 @@ if Code.ensure_loaded?(Igniter) do
     @strategy_tasks %{
       "password" => "ash_authentication.add_strategy.password",
       "magic_link" => "ash_authentication.add_strategy.magic_link",
-      "api_key" => "ash_authentication.add_strategy.api_key"
+      "api_key" => "ash_authentication.add_strategy.api_key",
+      "totp" => "ash_authentication.add_strategy.totp"
     }
 
     @moduledoc """
@@ -43,6 +45,7 @@ if Code.ensure_loaded?(Igniter) do
       * `mix ash_authentication.add_strategy.password`
       * `mix ash_authentication.add_strategy.magic_link`
       * `mix ash_authentication.add_strategy.api_key`
+      * `mix ash_authentication.add_strategy.totp`
 
     ## Example
 
@@ -59,6 +62,11 @@ if Code.ensure_loaded?(Igniter) do
     ## Password options
 
       - `hash-provider` - The hash provider to use, either `bcrypt` or `argon2`.  Defaults to `bcrypt`.
+
+    ## TOTP options
+
+      - `--mode`, `-m` - Either `primary` or `2fa`. Defaults to `2fa`.
+      - `--name`, `-n` - The name of the TOTP strategy. Defaults to `totp`.
     """
 
     def info(_argv, _composing_task) do
@@ -76,12 +84,16 @@ if Code.ensure_loaded?(Igniter) do
           user: :string,
           identity_field: :string,
           api_key: :string,
-          hash_provider: :string
+          hash_provider: :string,
+          mode: :string,
+          name: :string
         ],
         aliases: [
           a: :accounts,
           u: :user,
-          i: :identity_field
+          i: :identity_field,
+          m: :mode,
+          n: :name
         ],
         defaults: [
           identity_field: "email"

--- a/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
@@ -100,7 +100,7 @@ if Code.ensure_loaded?(Igniter) do
 
       igniter
       |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
-      attribute :#{options[:identity_field]}, :ci_string do
+      attribute #{inspect(options[:identity_field])}, :ci_string do
         allow_nil? false
         public? true
       end
@@ -123,8 +123,8 @@ if Code.ensure_loaded?(Igniter) do
         end
 
         upsert? true
-        upsert_identity :unique_#{options[:identity_field]}
-        upsert_fields [:#{options[:identity_field]}]
+        upsert_identity #{inspect(:"unique_#{options[:identity_field]}")}
+        upsert_fields [#{inspect(options[:identity_field])}]
 
         # Uses the information from the token to create or sign in the user
         change AshAuthentication.Strategy.MagicLink.SignInChange
@@ -139,7 +139,7 @@ if Code.ensure_loaded?(Igniter) do
       """)
       |> Ash.Resource.Igniter.add_new_action(options[:user], :request_magic_link, """
       action :request_magic_link do
-        argument :#{options[:identity_field]}, :ci_string do
+        argument #{inspect(options[:identity_field])}, :ci_string do
           allow_nil? false
         end
 
@@ -148,7 +148,7 @@ if Code.ensure_loaded?(Igniter) do
       """)
       |> AshAuthentication.Igniter.add_new_strategy(options[:user], :magic_link, :magic_link, """
       magic_link do
-        identity_field :#{options[:identity_field]}
+        identity_field #{inspect(options[:identity_field])}
         registration_enabled? true
         require_interaction? true
 
@@ -231,7 +231,8 @@ if Code.ensure_loaded?(Igniter) do
           /auth/user/magic_link/?token=\#{token}
           """)
         end
-        '''
+        ''',
+        on_exists: :warning
       )
     end
   end

--- a/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
@@ -203,89 +203,7 @@ if Code.ensure_loaded?(Igniter) do
       end)
     end
 
-    defp create_new_magic_link_sender(igniter, sender, options) do
-      case Igniter.Libs.Swoosh.list_mailers(igniter) do
-        {igniter, [mailer]} ->
-          {_web_module_exists?, use_web_module, igniter} =
-            AshAuthentication.Igniter.web_module_use_line(igniter)
-
-          url =
-            if use_web_module do
-              "\#{url(~p\"/magic_link/\#{params[:token]}\")}"
-            else
-              "/auth/user/magic_link?token=\#{params[:token]}"
-            end
-
-          Igniter.Project.Module.create_module(igniter, sender, ~s'''
-          @moduledoc """
-          Sends a magic link email
-          """
-
-          use AshAuthentication.Sender
-          #{use_web_module}
-
-          import Swoosh.Email
-          alias #{inspect(mailer)}
-
-          @impl true
-          def send(user_or_email, token, _) do
-            # if you get a user, its for a user that already exists.
-            # if you get an email, then the user does not yet exist.
-
-            email =
-              case user_or_email do
-                %{email: email} -> email
-                email -> email
-              end
-
-            new()
-            # TODO: Replace with your email
-            |> from({"noreply", "noreply@example.com"})
-            |> to(to_string(email))
-            |> subject("Your login link")
-            |> html_body(body([token: token, email: email]))
-            |> #{List.last(Module.split(mailer))}.deliver!()
-          end
-
-          defp body(params) do
-            # NOTE: You may have to change this to match your magic link acceptance URL.
-
-            """
-            <p>Hello, \#{params[:email]}! Click this link to sign in:</p>
-            <p><a href="#{url}">#{url}</a></p>
-            """
-          end
-          ''')
-
-        _ ->
-          create_example_new_magic_link_sender(igniter, sender, options)
-      end
-    end
-
-    defp create_example_new_magic_link_sender(igniter, sender, options) do
-      {web_module_exists?, use_web_module, igniter} =
-        AshAuthentication.Igniter.web_module_use_line(igniter)
-
-      example_domain = AshAuthentication.Igniter.parent_module(options[:user])
-
-      real_example =
-        if web_module_exists? do
-          """
-          # Example of how you might send this email
-          # #{inspect(example_domain)}.Emails.send_magic_link_email(
-          #   user_or_email,
-          #   token
-          # )
-          """
-        end
-
-      url =
-        if use_web_module do
-          "\#{url(~p\"/magic_link/\#{token}\")}"
-        else
-          "/auth/user/magic_link/?token=\#{token}"
-        end
-
+    defp create_new_magic_link_sender(igniter, sender, _options) do
       Igniter.Project.Module.create_module(
         igniter,
         sender,
@@ -295,13 +213,11 @@ if Code.ensure_loaded?(Igniter) do
         """
 
         use AshAuthentication.Sender
-        #{use_web_module}
 
         @impl true
         def send(user_or_email, token, _) do
           # if you get a user, its for a user that already exists.
           # if you get an email, then the user does not yet exist.
-          #{real_example}
 
           email =
             case user_or_email do
@@ -312,7 +228,7 @@ if Code.ensure_loaded?(Igniter) do
           IO.puts("""
           Hello, \#{email}! Click this link to sign in:
 
-          #{url}
+          /auth/user/magic_link/?token=\#{token}
           """)
         end
         '''

--- a/lib/mix/tasks/ash_authentication.add_strategy.password.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.password.ex
@@ -256,74 +256,7 @@ if Code.ensure_loaded?(Igniter) do
       """)
     end
 
-    defp create_reset_sender(igniter, sender, options) do
-      case Igniter.Libs.Swoosh.list_mailers(igniter) do
-        {igniter, [mailer]} ->
-          {_web_module_exists?, use_web_module, igniter} =
-            AshAuthentication.Igniter.web_module_use_line(igniter)
-
-          Igniter.Project.Module.create_module(igniter, sender, ~s'''
-          @moduledoc """
-          Sends a password reset email
-          """
-
-          use AshAuthentication.Sender
-          #{use_web_module}
-
-          import Swoosh.Email
-
-          alias #{inspect(mailer)}
-
-          @impl true
-          def send(user, token, _) do
-            new()
-            # TODO: Replace with your email
-            |> from({"noreply", "noreply@example.com"})
-            |> to(to_string(user.email))
-            |> subject("Reset your password")
-            |> html_body(body([token: token]))
-            |> #{List.last(Module.split(mailer))}.deliver!()
-          end
-
-          defp body(params) do
-            url = url(~p"/password-reset/\#{params[:token]}")
-
-            """
-            <p>Click this link to reset your password:</p>
-            <p><a href="\#{url}">\#{url}</a></p>
-            """
-          end
-          ''')
-
-        _ ->
-          create_example_reset_sender(igniter, sender, options)
-      end
-    end
-
-    defp create_example_reset_sender(igniter, sender, options) do
-      {web_module_exists?, use_web_module, igniter} =
-        AshAuthentication.Igniter.web_module_use_line(igniter)
-
-      example_domain = AshAuthentication.Igniter.parent_module(options[:user])
-
-      real_example =
-        if web_module_exists? do
-          """
-          # Example of how you might send this email
-          # #{inspect(example_domain)}.Emails.send_password_reset_email(
-          #   user,
-          #   token
-          # )
-          """
-        end
-
-      url =
-        if use_web_module do
-          "\#{url(~p\"/password-reset/\#{token}\")}"
-        else
-          "/password-reset/\#{token}"
-        end
-
+    defp create_reset_sender(igniter, sender, _options) do
       Igniter.Project.Module.create_module(
         igniter,
         sender,
@@ -333,15 +266,13 @@ if Code.ensure_loaded?(Igniter) do
         """
 
         use AshAuthentication.Sender
-        #{use_web_module}
 
         @impl true
         def send(_user, token, _) do
-          #{real_example}
           IO.puts("""
           Click this link to reset your password:
 
-          #{url}
+          /password-reset/\#{token}
           """)
         end
         '''

--- a/lib/mix/tasks/ash_authentication.add_strategy.password.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.password.ex
@@ -136,7 +136,7 @@ if Code.ensure_loaded?(Igniter) do
 
       igniter
       |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
-      attribute :#{options[:identity_field]}, :ci_string do
+      attribute #{inspect(options[:identity_field])}, :ci_string do
         allow_nil? false
         public? true
       end
@@ -150,7 +150,7 @@ if Code.ensure_loaded?(Igniter) do
       |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
       |> AshAuthentication.Igniter.add_new_strategy(options[:user], :password, :password, """
       password :password do
-        identity_field :#{options[:identity_field]}
+        identity_field #{inspect(options[:identity_field])}
         hash_provider #{hash_provider}
 
         resettable do
@@ -211,12 +211,12 @@ if Code.ensure_loaded?(Igniter) do
         action :request_password_reset_token do
           description "Send password reset instructions to a user if they exist."
 
-          argument :#{options[:identity_field]}, :ci_string do
+          argument #{inspect(options[:identity_field])}, :ci_string do
             allow_nil? false
           end
 
           # creates a reset token and invokes the relevant senders
-          run {AshAuthentication.Strategy.Password.RequestPasswordReset, action: :get_by_#{options[:identity_field]}}
+          run {AshAuthentication.Strategy.Password.RequestPasswordReset, action: #{inspect(:"get_by_#{options[:identity_field]}")}}
         end
         """
       )
@@ -275,7 +275,8 @@ if Code.ensure_loaded?(Igniter) do
           /password-reset/\#{token}
           """)
         end
-        '''
+        ''',
+        on_exists: :warning
       )
     end
 
@@ -286,7 +287,7 @@ if Code.ensure_loaded?(Igniter) do
         description "Attempt to sign in using a #{options[:identity_field]} and password."
         get? true
 
-        argument :#{options[:identity_field]}, :ci_string do
+        argument #{inspect(options[:identity_field])}, :ci_string do
           description "The #{options[:identity_field]} to use for retrieving the user."
           allow_nil? false
         end
@@ -346,7 +347,7 @@ if Code.ensure_loaded?(Igniter) do
       |> Ash.Resource.Igniter.add_new_action(options[:user], :register_with_password, """
       create :register_with_password do
         description "Register a new user with a #{options[:identity_field]} and password."
-        argument :#{options[:identity_field]}, :ci_string do
+        argument #{inspect(options[:identity_field])}, :ci_string do
           allow_nil? false
         end
 
@@ -364,7 +365,7 @@ if Code.ensure_loaded?(Igniter) do
         end
 
         # Sets the #{options[:identity_field]} from the argument
-        change set_attribute(:#{options[:identity_field]}, arg(:#{options[:identity_field]}))
+        change set_attribute(#{inspect(options[:identity_field])}, arg(#{inspect(options[:identity_field])}))
 
         # Hashes the provided password
         change AshAuthentication.Strategy.Password.HashPasswordChange

--- a/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
@@ -153,8 +153,8 @@ if Code.ensure_loaded?(Igniter) do
         end
 
       """
-      totp :#{options[:name]} do
-        identity_field :#{options[:identity_field]}#{sign_in_line}
+      totp #{inspect(options[:name])} do
+        identity_field #{inspect(options[:identity_field])}#{sign_in_line}
         confirm_setup_enabled? true
         brute_force_strategy {:audit_log, :audit_log}
       end

--- a/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Totp do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.totp --mode 2fa"
+
+    @shortdoc "Adds TOTP authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    TOTP can be used in two modes:
+
+      * `2fa` - As a second factor after password authentication (default)
+      * `primary` - As the primary authentication method (passwordless)
+
+    Both modes use an audit log add-on for brute force protection, which will be
+    created automatically if one doesn't already exist.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--identity-field`, `-i` - The field on the user resource that will be used to identify
+      the user. Defaults to `email`
+    * `--mode`, `-m` - Either `primary` or `2fa`. Defaults to `2fa`.
+    * `--name`, `-n` - The name of the TOTP strategy. Defaults to `totp`.
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [
+          "ash_authentication.add_add_on.audit_log"
+        ],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          mode: :string,
+          name: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field,
+          m: :mode,
+          n: :name
+        ],
+        defaults: [
+          identity_field: "email",
+          mode: "2fa",
+          name: "totp"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      if options[:mode] not in [:primary, :"2fa"] do
+        Mix.shell().error("""
+        Invalid mode: #{inspect(options[:mode])}
+
+        Available modes:
+
+          * `2fa` - Use TOTP as a second factor after password authentication
+          * `primary` - Use TOTP as the primary authentication method
+        """)
+
+        exit({:shutdown, 1})
+      end
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          igniter
+          |> totp(options)
+          |> Ash.Igniter.codegen("add_totp_auth")
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update(:mode, :"2fa", &String.to_atom/1)
+      |> Keyword.update(:name, :totp, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+
+    defp totp(igniter, options) do
+      igniter
+      |> Ash.Resource.Igniter.add_new_attribute(options[:user], :totp_secret, """
+      attribute :totp_secret, :binary do
+        allow_nil? true
+        sensitive? true
+        public? false
+      end
+      """)
+      |> Ash.Resource.Igniter.add_new_attribute(options[:user], :last_totp_at, """
+      attribute :last_totp_at, :utc_datetime do
+        allow_nil? true
+        sensitive? true
+        public? false
+      end
+      """)
+      |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+      |> compose_audit_log(options)
+      |> AshAuthentication.Igniter.add_new_strategy(
+        options[:user],
+        :totp,
+        options[:name],
+        build_strategy_config(options)
+      )
+      |> maybe_add_phoenix_integration(options)
+    end
+
+    defp build_strategy_config(options) do
+      sign_in_line =
+        if options[:mode] == :primary do
+          "\n    sign_in_enabled? true"
+        else
+          ""
+        end
+
+      """
+      totp :#{options[:name]} do
+        identity_field :#{options[:identity_field]}#{sign_in_line}
+        confirm_setup_enabled? true
+        brute_force_strategy {:audit_log, :audit_log}
+      end
+      """
+    end
+
+    defp compose_audit_log(igniter, options) do
+      {igniter, has_audit_log?} =
+        AshAuthentication.Igniter.defines_add_on(igniter, options[:user], :audit_log, nil)
+
+      if has_audit_log? do
+        igniter
+      else
+        Igniter.compose_task(
+          igniter,
+          "ash_authentication.add_add_on.audit_log",
+          ["--user", inspect(options[:user])]
+        )
+      end
+    end
+
+    defp maybe_add_phoenix_integration(igniter, options) do
+      if Code.ensure_loaded?(AshAuthentication.Phoenix) do
+        igniter
+        |> add_route_instructions(options)
+        |> maybe_modify_controller(options)
+      else
+        igniter
+      end
+    end
+
+    defp add_route_instructions(igniter, options) do
+      user = inspect(options[:user])
+      strategy_name = inspect(options[:name])
+
+      routes =
+        if options[:mode] == :"2fa" do
+          """
+          Add the following TOTP routes to your router:
+
+            # In a scope that does NOT require authentication (e.g. alongside your sign_in_route):
+            totp_2fa_route #{user}, #{strategy_name}
+
+            # In a scope that requires authentication (e.g. alongside your protected LiveView routes):
+            totp_setup_route #{user}, #{strategy_name}
+          """
+        else
+          """
+          Add the following TOTP route to your router:
+
+            # In a scope that requires authentication:
+            totp_setup_route #{user}, #{strategy_name}
+          """
+        end
+
+      Igniter.add_warning(igniter, routes)
+    end
+
+    defp maybe_modify_controller(igniter, options) do
+      if options[:mode] == :"2fa" do
+        modify_controller_for_2fa(igniter)
+      else
+        igniter
+      end
+    end
+
+    defp modify_controller_for_2fa(igniter) do
+      web_module = Igniter.Libs.Phoenix.web_module(igniter)
+      controller = Module.concat(web_module, AuthController)
+
+      {exists?, igniter} = Igniter.Project.Module.module_exists(igniter, controller)
+
+      if exists? do
+        replace_controller_success(igniter, controller)
+      else
+        Igniter.add_warning(igniter, """
+        Could not find AuthController at #{inspect(controller)}.
+
+        You will need to manually update your auth controller's success/4 function
+        to handle TOTP 2FA redirects. See the TOTP tutorial for details.
+        """)
+      end
+    end
+
+    defp replace_controller_success(igniter, controller) do
+      Igniter.Project.Module.find_and_update_module!(igniter, controller, fn zipper ->
+        case Igniter.Code.Function.move_to_def(zipper, :success, 4) do
+          {:ok, zipper} ->
+            zipper =
+              zipper
+              |> Igniter.Code.Common.add_code(totp_registration_clause(), placement: :before)
+              |> Igniter.Code.Common.add_code(totp_sign_in_clause(), placement: :before)
+
+            {:ok, zipper}
+
+          _ ->
+            {:ok, zipper}
+        end
+      end)
+    end
+
+    defp totp_sign_in_clause do
+      ~S"""
+      def success(conn, {_, phase} = _activity, user, token)
+          when phase in [:sign_in, :sign_in_with_token] do
+        return_to = get_session(conn, :return_to) || ~p"/"
+
+        if AshAuthentication.Phoenix.TotpHelpers.totp_configured?(user) do
+          conn
+          |> put_session(:return_to, return_to)
+          |> redirect(to: ~p"/totp-verify/#{token}")
+        else
+          conn
+          |> delete_session(:return_to)
+          |> store_in_session(user)
+          |> set_live_socket_id(token)
+          |> assign(:current_user, user)
+          |> put_flash(:info, "You are now signed in")
+          |> redirect(to: return_to)
+        end
+      end
+      """
+    end
+
+    defp totp_registration_clause do
+      ~S"""
+      # After registration, redirect to TOTP setup so the user can configure
+      # their authenticator app.
+      # To make TOTP setup optional for some users, add a condition here, e.g.:
+      #   if user.totp_required, do: redirect to setup, else: call default success
+      # If a user navigates away without completing setup, use the RequireTotp
+      # plug or on_mount hook to enforce TOTP on protected routes.
+      def success(conn, {_, :register}, user, token) do
+        return_to = get_session(conn, :return_to) || ~p"/"
+
+        conn
+        |> store_in_session(user)
+        |> set_live_socket_id(token)
+        |> assign(:current_user, user)
+        |> put_session(:return_to, return_to)
+        |> redirect(to: ~p"/totp-setup")
+      end
+      """
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Totp do
+    @shortdoc "Adds TOTP authentication to your user resource"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication.add_strategy.totp' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
@@ -128,7 +128,7 @@ if Code.ensure_loaded?(Igniter) do
       end
       """)
       |> Ash.Resource.Igniter.add_new_attribute(options[:user], :last_totp_at, """
-      attribute :last_totp_at, :utc_datetime do
+      attribute :last_totp_at, :datetime do
         allow_nil? true
         sensitive? true
         public? false
@@ -142,7 +142,6 @@ if Code.ensure_loaded?(Igniter) do
         options[:name],
         build_strategy_config(options)
       )
-      |> maybe_add_phoenix_integration(options)
     end
 
     defp build_strategy_config(options) do
@@ -175,130 +174,6 @@ if Code.ensure_loaded?(Igniter) do
           ["--user", inspect(options[:user])]
         )
       end
-    end
-
-    defp maybe_add_phoenix_integration(igniter, options) do
-      if Code.ensure_loaded?(AshAuthentication.Phoenix) do
-        igniter
-        |> add_route_instructions(options)
-        |> maybe_modify_controller(options)
-      else
-        igniter
-      end
-    end
-
-    defp add_route_instructions(igniter, options) do
-      user = inspect(options[:user])
-      strategy_name = inspect(options[:name])
-
-      routes =
-        if options[:mode] == :"2fa" do
-          """
-          Add the following TOTP routes to your router:
-
-            # In a scope that does NOT require authentication (e.g. alongside your sign_in_route):
-            totp_2fa_route #{user}, #{strategy_name}
-
-            # In a scope that requires authentication (e.g. alongside your protected LiveView routes):
-            totp_setup_route #{user}, #{strategy_name}
-          """
-        else
-          """
-          Add the following TOTP route to your router:
-
-            # In a scope that requires authentication:
-            totp_setup_route #{user}, #{strategy_name}
-          """
-        end
-
-      Igniter.add_warning(igniter, routes)
-    end
-
-    defp maybe_modify_controller(igniter, options) do
-      if options[:mode] == :"2fa" do
-        modify_controller_for_2fa(igniter)
-      else
-        igniter
-      end
-    end
-
-    defp modify_controller_for_2fa(igniter) do
-      web_module = Igniter.Libs.Phoenix.web_module(igniter)
-      controller = Module.concat(web_module, AuthController)
-
-      {exists?, igniter} = Igniter.Project.Module.module_exists(igniter, controller)
-
-      if exists? do
-        replace_controller_success(igniter, controller)
-      else
-        Igniter.add_warning(igniter, """
-        Could not find AuthController at #{inspect(controller)}.
-
-        You will need to manually update your auth controller's success/4 function
-        to handle TOTP 2FA redirects. See the TOTP tutorial for details.
-        """)
-      end
-    end
-
-    defp replace_controller_success(igniter, controller) do
-      Igniter.Project.Module.find_and_update_module!(igniter, controller, fn zipper ->
-        case Igniter.Code.Function.move_to_def(zipper, :success, 4) do
-          {:ok, zipper} ->
-            zipper =
-              zipper
-              |> Igniter.Code.Common.add_code(totp_registration_clause(), placement: :before)
-              |> Igniter.Code.Common.add_code(totp_sign_in_clause(), placement: :before)
-
-            {:ok, zipper}
-
-          _ ->
-            {:ok, zipper}
-        end
-      end)
-    end
-
-    defp totp_sign_in_clause do
-      ~S"""
-      def success(conn, {_, phase} = _activity, user, token)
-          when phase in [:sign_in, :sign_in_with_token] do
-        return_to = get_session(conn, :return_to) || ~p"/"
-
-        if AshAuthentication.Phoenix.TotpHelpers.totp_configured?(user) do
-          conn
-          |> put_session(:return_to, return_to)
-          |> redirect(to: ~p"/totp-verify/#{token}")
-        else
-          conn
-          |> delete_session(:return_to)
-          |> store_in_session(user)
-          |> set_live_socket_id(token)
-          |> assign(:current_user, user)
-          |> put_flash(:info, "You are now signed in")
-          |> redirect(to: return_to)
-        end
-      end
-      """
-    end
-
-    defp totp_registration_clause do
-      ~S"""
-      # After registration, redirect to TOTP setup so the user can configure
-      # their authenticator app.
-      # To make TOTP setup optional for some users, add a condition here, e.g.:
-      #   if user.totp_required, do: redirect to setup, else: call default success
-      # If a user navigates away without completing setup, use the RequireTotp
-      # plug or on_mount hook to enforce TOTP on protected routes.
-      def success(conn, {_, :register}, user, token) do
-        return_to = get_session(conn, :return_to) || ~p"/"
-
-        conn
-        |> store_in_session(user)
-        |> set_live_socket_id(token)
-        |> assign(:current_user, user)
-        |> put_session(:return_to, return_to)
-        |> redirect(to: ~p"/totp-setup")
-      end
-      """
     end
   end
 else

--- a/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategy.TotpTest do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
       |> assert_has_patch("lib/test/accounts/user.ex", """
-      + |    attribute :last_totp_at, :utc_datetime do
+      + |    attribute :last_totp_at, :datetime do
       + |      allow_nil?(true)
       + |      sensitive?(true)
       + |      public?(false)
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategy.TotpTest do
       + |    end
       """)
       |> assert_has_patch("lib/test/accounts/user.ex", """
-      + |    attribute :last_totp_at, :utc_datetime do
+      + |    attribute :last_totp_at, :datetime do
       + |      allow_nil?(true)
       + |      sensitive?(true)
       + |      public?(false)
@@ -231,102 +231,6 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategy.TotpTest do
       + |      brute_force_strategy({:audit_log, :audit_log})
       + |    end
       """)
-    end
-  end
-
-  describe "phoenix integration" do
-    setup do
-      igniter =
-        test_project()
-        |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
-        |> Igniter.compose_task("ash_authentication.install", ["--yes"])
-        |> Igniter.Project.Formatter.remove_imported_dep(:ash_authentication)
-        |> Igniter.Project.Formatter.remove_formatter_plugin(Spark.Formatter)
-        |> Igniter.Project.Module.create_module(TestWeb.AuthController, """
-        def success(conn, activity, user, token) do
-          return_to = get_session(conn, :return_to) || ~p"/"
-
-          message =
-            case activity do
-              {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
-              {:password, :reset} -> "Your password has successfully been reset"
-              _ -> "You are now signed in"
-            end
-
-          conn
-          |> delete_session(:return_to)
-          |> store_in_session(user)
-          |> set_live_socket_id(token)
-          |> assign(:current_user, user)
-          |> put_flash(:info, message)
-          |> redirect(to: return_to)
-        end
-
-        def failure(conn, _activity, _reason) do
-          conn
-          |> put_flash(:error, "Incorrect email or password")
-          |> redirect(to: ~p"/sign-in")
-        end
-
-        def sign_out(conn, _params) do
-          conn
-          |> redirect(to: ~p"/")
-        end
-        """)
-        |> apply_igniter!()
-
-      [igniter: igniter]
-    end
-
-    test "inserts sign-in interception clause before existing success/4 in 2fa mode", %{
-      igniter: igniter
-    } do
-      igniter
-      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
-      |> assert_has_patch("lib/test_web/auth_controller.ex", """
-      + |  def success(conn, {_, phase} = _activity, user, token)
-      + |      when phase in [:sign_in, :sign_in_with_token] do
-      """)
-    end
-
-    test "inserts registration redirect clause before existing success/4 in 2fa mode", %{
-      igniter: igniter
-    } do
-      igniter
-      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
-      |> assert_has_patch("lib/test_web/auth_controller.ex", """
-      + |  def success(conn, {_, :register}, user, token) do
-      """)
-    end
-
-    test "does not modify the existing catch-all success clause", %{igniter: igniter} do
-      result =
-        igniter
-        |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
-
-      # The existing function should not show as removed
-      refute diff(result, path: "lib/test_web/auth_controller.ex") =~ "- |  def success"
-    end
-
-    test "does not modify controller in primary mode", %{igniter: igniter} do
-      igniter
-      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
-      |> assert_unchanged("lib/test_web/auth_controller.ex")
-    end
-
-    test "emits route instructions as warnings in 2fa mode", %{igniter: igniter} do
-      igniter
-      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
-      |> assert_has_warning(&String.contains?(&1, "totp_2fa_route"))
-    end
-
-    test "emits only setup route instruction in primary mode", %{igniter: igniter} do
-      result =
-        igniter
-        |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
-
-      assert_has_warning(result, &String.contains?(&1, "totp_setup_route"))
-      refute Enum.any?(result.warnings, &String.contains?(&1, "totp_2fa_route"))
     end
   end
 end

--- a/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Mix.Tasks.AshAuthentication.AddStrategy.TotpTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  setup do
+    igniter =
+      test_project()
+      |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+      |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+      # These can be removed when https://github.com/hrzndhrn/rewrite/issues/39 is addressed (in igniter too)
+      |> Igniter.Project.Formatter.remove_imported_dep(:ash_authentication)
+      |> Igniter.Project.Formatter.remove_formatter_plugin(Spark.Formatter)
+      |> apply_igniter!()
+
+    [igniter: igniter]
+  end
+
+  describe "2fa mode (default)" do
+    test "adds totp_secret attribute to the user", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    attribute :totp_secret, :binary do
+      + |      allow_nil?(true)
+      + |      sensitive?(true)
+      + |      public?(false)
+      + |    end
+      """)
+    end
+
+    test "adds last_totp_at attribute to the user", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    attribute :last_totp_at, :utc_datetime do
+      + |      allow_nil?(true)
+      + |      sensitive?(true)
+      + |      public?(false)
+      + |    end
+      """)
+    end
+
+    test "adds the totp strategy in 2fa mode", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+
+    test "does not enable sign_in in 2fa mode", %{igniter: igniter} do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+
+      refute diff(result) =~ "sign_in_enabled?"
+    end
+
+    test "composes the audit_log add-on", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |      audit_log do
+      + |        audit_log_resource(Test.Accounts.AuditLog)
+      + |      end
+      """)
+    end
+
+    test "creates the audit_log resource", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_creates("lib/test/accounts/audit_log.ex")
+    end
+
+    test "ensures the identity for the identity field", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |  identities do
+      + |    identity(:unique_email, [:email])
+      + |  end
+      """)
+    end
+  end
+
+  describe "via parent task" do
+    test "2fa mode can be invoked via ash_authentication.add_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["totp"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+
+    test "primary mode can be invoked via ash_authentication.add_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["totp", "--mode", "primary"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      sign_in_enabled?(true)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+  end
+
+  describe "primary mode" do
+    test "adds the totp strategy with sign_in_enabled", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      sign_in_enabled?(true)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+
+    test "still adds both attributes", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    attribute :totp_secret, :binary do
+      + |      allow_nil?(true)
+      + |      sensitive?(true)
+      + |      public?(false)
+      + |    end
+      """)
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    attribute :last_totp_at, :utc_datetime do
+      + |      allow_nil?(true)
+      + |      sensitive?(true)
+      + |      public?(false)
+      + |    end
+      """)
+    end
+  end
+
+  describe "custom options" do
+    test "supports custom strategy name", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--name", "my_totp"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :my_totp do
+      + |      identity_field(:email)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+
+    test "supports custom identity field", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [
+        "--identity-field",
+        "username"
+      ])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:username)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+  end
+
+  describe "error handling" do
+    test "shows error for missing user resource", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [
+        "--user",
+        "NonExistent.User"
+      ])
+      |> assert_has_issue(&String.contains?(&1, "User module NonExistent.User was not found"))
+    end
+  end
+
+  describe "idempotency" do
+    test "does not duplicate audit log add-on when already present", %{igniter: igniter} do
+      igniter =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_add_on", ["audit_log"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+  end
+
+  describe "combination with password strategy" do
+    test "can add totp after password", %{igniter: igniter} do
+      igniter =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    totp :totp do
+      + |      identity_field(:email)
+      + |      confirm_setup_enabled?(true)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |    end
+      """)
+    end
+  end
+
+  describe "phoenix integration" do
+    setup do
+      igniter =
+        test_project()
+        |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+        |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+        |> Igniter.Project.Formatter.remove_imported_dep(:ash_authentication)
+        |> Igniter.Project.Formatter.remove_formatter_plugin(Spark.Formatter)
+        |> Igniter.Project.Module.create_module(TestWeb.AuthController, """
+        def success(conn, activity, user, token) do
+          return_to = get_session(conn, :return_to) || ~p"/"
+
+          message =
+            case activity do
+              {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
+              {:password, :reset} -> "Your password has successfully been reset"
+              _ -> "You are now signed in"
+            end
+
+          conn
+          |> delete_session(:return_to)
+          |> store_in_session(user)
+          |> set_live_socket_id(token)
+          |> assign(:current_user, user)
+          |> put_flash(:info, message)
+          |> redirect(to: return_to)
+        end
+
+        def failure(conn, _activity, _reason) do
+          conn
+          |> put_flash(:error, "Incorrect email or password")
+          |> redirect(to: ~p"/sign-in")
+        end
+
+        def sign_out(conn, _params) do
+          conn
+          |> redirect(to: ~p"/")
+        end
+        """)
+        |> apply_igniter!()
+
+      [igniter: igniter]
+    end
+
+    test "inserts sign-in interception clause before existing success/4 in 2fa mode", %{
+      igniter: igniter
+    } do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_patch("lib/test_web/auth_controller.ex", """
+      + |  def success(conn, {_, phase} = _activity, user, token)
+      + |      when phase in [:sign_in, :sign_in_with_token] do
+      """)
+    end
+
+    test "inserts registration redirect clause before existing success/4 in 2fa mode", %{
+      igniter: igniter
+    } do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_patch("lib/test_web/auth_controller.ex", """
+      + |  def success(conn, {_, :register}, user, token) do
+      """)
+    end
+
+    test "does not modify the existing catch-all success clause", %{igniter: igniter} do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
+
+      # The existing function should not show as removed
+      refute diff(result, path: "lib/test_web/auth_controller.ex") =~ "- |  def success"
+    end
+
+    test "does not modify controller in primary mode", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
+      |> assert_unchanged("lib/test_web/auth_controller.ex")
+    end
+
+    test "emits route instructions as warnings in 2fa mode", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_warning(&String.contains?(&1, "totp_2fa_route"))
+    end
+
+    test "emits only setup route instruction in primary mode", %{igniter: igniter} do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_strategy.totp", ["--mode", "primary"])
+
+      assert_has_warning(result, &String.contains?(&1, "totp_setup_route"))
+      refute Enum.any?(result.warnings, &String.contains?(&1, "totp_2fa_route"))
+    end
+  end
+end

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -344,38 +344,7 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       """)
     end
 
-    test "creates a phoenix-idiomatic password reset sender", %{igniter: igniter} do
-      igniter
-      |> Igniter.Project.Module.create_module(TestWeb, "")
-      |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
-      |> assert_creates("lib/test/accounts/user/senders/send_password_reset_email.ex", """
-      defmodule Test.Accounts.User.Senders.SendPasswordResetEmail do
-        @moduledoc \"\"\"
-        Sends a password reset email
-        \"\"\"
-
-        use AshAuthentication.Sender
-        use TestWeb, :verified_routes
-
-        @impl true
-        def send(_user, token, _) do
-          # Example of how you might send this email
-          # Test.Accounts.Emails.send_password_reset_email(
-          #   user,
-          #   token
-          # )
-
-          IO.puts(\"\"\"
-          Click this link to reset your password:
-
-          \#{url(~p"/password-reset/\#{token}")}
-          \"\"\")
-        end
-      end
-      """)
-    end
-
-    test "creates a plain password reset sender if you are not using phoenix", %{igniter: igniter} do
+    test "creates a basic password reset sender", %{igniter: igniter} do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
       |> assert_creates("lib/test/accounts/user/senders/send_password_reset_email.ex", """

--- a/test/support/ash_authentication_phoenix_stub.ex
+++ b/test/support/ash_authentication_phoenix_stub.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# Stub module so that Code.ensure_loaded?(AshAuthentication.Phoenix) returns
+# true during tests. This allows the TOTP generator's Phoenix integration
+# branch to be exercised without introducing a circular dependency on the
+# real ash_authentication_phoenix package.
+unless Code.ensure_loaded?(AshAuthentication.Phoenix) do
+  defmodule AshAuthentication.Phoenix do
+    @moduledoc false
+  end
+end


### PR DESCRIPTION
## Summary

- Add new per-strategy igniter tasks for TOTP (`ash_authentication.add_strategy.totp`), including resource-level setup (attributes, identity, audit log, strategy DSL config)
- Strip all Phoenix-specific code from AA's igniter tasks (TOTP controller mods, Swoosh/verified-routes sender generation, `web_module_use_line` helper)
- AA now generates only resource-level / Plug-based code — Phoenix integration moves to `ash_authentication_phoenix`'s new convention-named strategy tasks
- Fix TOTP verify plug to strip extra form params that aren't action arguments
- Fix `:utc_datetime` → `:datetime` in TOTP test assertions

## Context

Part of a two-repo restructure following the convention-routed composition pattern from `phx_install`. The companion PR in `ash_authentication_phoenix` adds new strategy tasks that own the Phoenix-specific code removed here.

## Test plan

- [x] `mix check --no-retry` passes (all 14 checks green)
- [x] 63 igniter tests pass
- [x] End-to-end tested with `nietflix` test app (magic link + TOTP 2FA flow)