### PR TITLE
feat: add Igniter generators for OAuth2/OIDC strategies

### DIFF
--- a/documentation/tutorials/auth0.md
+++ b/documentation/tutorials/auth0.md
@@ -8,6 +8,18 @@ SPDX-License-Identifier: MIT
 
 This is a quick tutorial on how to configure your application to use Auth0 for authentication.
 
+## Quick setup with Igniter
+
+The fastest way to add Auth0 authentication is with the Igniter generator:
+
+```bash
+mix ash_authentication.add_strategy auth0
+```
+
+This creates the UserIdentity resource, register action, secrets wiring, and strategy DSL for you. Follow the printed instructions to create your Auth0 application and set the required environment variables (including your tenant's base URL). The rest of this tutorial covers manual setup.
+
+## Manual setup
+
 First, you need to configure an application in [the Auth0 dashboard](https://manage.auth0.com/) using the following steps:
 
 1. Click "Create Application".
@@ -121,11 +133,7 @@ defmodule MyApp.Accounts.User do
       # Required if you have the `identity_resource` configuration enabled.
       change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-      change fn changeset, _ ->
-        user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-        Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-      end
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
     end
   end
 

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -349,10 +349,7 @@ create :register_with_github do
   change AshAuthentication.Strategy.OAuth2.IdentityChange
   
   # Extract user data from OAuth response:
-  change fn changeset, _ctx ->
-    user_info = Ash.Changeset.get_argument(changeset, :user_info)
-    Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email", "name"]))
-  end
+  change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email, :name]}
 end
 ```
 

--- a/documentation/tutorials/github.md
+++ b/documentation/tutorials/github.md
@@ -8,6 +8,18 @@ SPDX-License-Identifier: MIT
 
 This is a quick tutorial on how to configure your application to use GitHub for authentication.
 
+## Quick setup with Igniter
+
+The fastest way to add GitHub authentication is with the Igniter generator:
+
+```bash
+mix ash_authentication.add_strategy github
+```
+
+This creates the UserIdentity resource, register action, secrets wiring, and strategy DSL for you. Follow the printed instructions to create your GitHub OAuth App and set the required environment variables. The rest of this tutorial covers manual setup.
+
+## Manual setup
+
 First you need to configure an application in your [GitHub developer settings](https://github.com/settings/developers):
 
 1. Click the "New OAuth App" button.
@@ -132,11 +144,7 @@ defmodule MyApp.Accounts.User do
       # Required if you have the `identity_resource` configuration enabled.
       change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-      change fn changeset, _ ->
-        user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-        Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-      end
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
 
       # Required if you're using the password & confirmation strategies
       upsert_fields []

--- a/documentation/tutorials/google.md
+++ b/documentation/tutorials/google.md
@@ -8,6 +8,18 @@ SPDX-License-Identifier: MIT
 
 This is a quick tutorial on how to configure Google authentication.
 
+## Quick setup with Igniter
+
+The fastest way to add Google authentication is with the Igniter generator:
+
+```bash
+mix ash_authentication.add_strategy google
+```
+
+This creates the UserIdentity resource, register action, secrets wiring, and strategy DSL for you. Follow the printed instructions to create your Google OAuth Client and set the required environment variables. The rest of this tutorial covers manual setup.
+
+## Manual setup
+
 First you'll need a registered application in [Google Cloud](https://console.cloud.google.com/welcome), in order to get your OAuth 2.0 Client credentials.
 
 1. On the Cloud's console **Quick access** section select **APIs & Services**, then **Credentials**
@@ -62,11 +74,7 @@ defmodule MyApp.Accounts.User do
       # Required if you have the `identity_resource` configuration enabled.
       change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-      change fn changeset, _ ->
-        user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-        Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-      end
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
 
       # Required if you're using the password & confirmation strategies
       upsert_fields []

--- a/documentation/tutorials/microsoft.md
+++ b/documentation/tutorials/microsoft.md
@@ -8,6 +8,18 @@ SPDX-License-Identifier: MIT
 
 This is a quick tutorial on how to configure Microsoft (Azure AD) authentication.
 
+## Quick setup with Igniter
+
+The fastest way to add Microsoft authentication is with the Igniter generator:
+
+```bash
+mix ash_authentication.add_strategy microsoft
+```
+
+This creates the UserIdentity resource, register action, secrets wiring, and strategy DSL for you. Follow the printed instructions to register your Azure AD application and set the required environment variables. The rest of this tutorial covers manual setup.
+
+## Manual setup
+
 First you'll need a registered application in the [Microsoft Entra admin center](https://entra.microsoft.com/), in order to get your OAuth 2.0 credentials.
 
 1. Under the **Entra ID** fan click **App registrations**
@@ -79,11 +91,7 @@ defmodule MyApp.Accounts.User do
       # Required if you have the `identity_resource` configuration enabled.
       change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-      change fn changeset, _ ->
-        user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-        Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-      end
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
 
       # Required if you're using the password & confirmation strategies
       upsert_fields []

--- a/documentation/tutorials/slack.md
+++ b/documentation/tutorials/slack.md
@@ -8,6 +8,18 @@ SPDX-License-Identifier: MIT
 
 This is a quick tutorial on how to configure your application to use Slack for authentication.
 
+## Quick setup with Igniter
+
+The fastest way to add Slack authentication is with the Igniter generator:
+
+```bash
+mix ash_authentication.add_strategy slack
+```
+
+This creates the UserIdentity resource, register action, secrets wiring, and strategy DSL for you. Follow the printed instructions to create your Slack app and set the required environment variables. The rest of this tutorial covers manual setup.
+
+## Manual setup
+
 First you need to configure an application in your [Slack app settings](https://api.slack.com/apps):
 
 1. Click the "Create New App" button.
@@ -141,11 +153,7 @@ defmodule MyApp.Accounts.User do
       # Required if you have the `identity_resource` configuration enabled.
       change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-      change fn changeset, _ ->
-        user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-        Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-      end
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
 
       # Required if you're using the password & confirmation strategies
       upsert_fields []

--- a/lib/ash_authentication/igniter.ex
+++ b/lib/ash_authentication/igniter.ex
@@ -436,10 +436,7 @@ if Code.ensure_loaded?(Igniter) do
           change AshAuthentication.GenerateTokenChange
           #{identity_change_line}
 
-          change fn changeset, _ctx ->
-            user_info = Ash.Changeset.get_argument(changeset, :user_info)
-            Ash.Changeset.change_attribute(changeset, :#{identity_field}, user_info["#{identity_field}"])
-          end
+          change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [#{inspect(identity_field)}]}
         end
         """
       )

--- a/lib/ash_authentication/igniter.ex
+++ b/lib/ash_authentication/igniter.ex
@@ -360,6 +360,150 @@ if Code.ensure_loaded?(Igniter) do
       Ash.Igniter.codegen(igniter, "add_#{strategy_name}_auth_strategy")
     end
 
+    @doc """
+    Ensures a UserIdentity resource exists for the given user resource.
+
+    If the identity resource module already exists, this is a no-op.
+    Otherwise, generates a new resource with the `AshAuthentication.UserIdentity`
+    extension. The extension auto-generates all attributes, relationships, actions,
+    and identities — this function only creates the resource shell.
+    """
+    @spec ensure_user_identity_resource(Igniter.t(), module(), module()) :: Igniter.t()
+    def ensure_user_identity_resource(igniter, user_resource, identity_resource) do
+      {exists?, igniter} = Igniter.Project.Module.module_exists(igniter, identity_resource)
+
+      if exists? do
+        igniter
+      else
+        igniter
+        |> Igniter.compose_task(
+          "ash.gen.resource",
+          [inspect(identity_resource), "--default-actions", "read"] ++
+            data_layer_extension_args()
+        )
+        |> Igniter.compose_task(
+          "ash.extend",
+          [inspect(identity_resource), "AshAuthentication.UserIdentity,Ash.Policy.Authorizer"]
+        )
+        |> Spark.Igniter.set_option(
+          identity_resource,
+          [:user_identity, :user_resource],
+          user_resource
+        )
+        |> maybe_set_postgres_table(identity_resource)
+        |> Ash.Resource.Igniter.add_bypass(
+          identity_resource,
+          quote do
+            AshAuthentication.Checks.AshAuthenticationInteraction
+          end,
+          quote do
+            authorize_if always()
+          end
+        )
+      end
+    end
+
+    @doc """
+    Adds an OAuth2 register action to a user resource.
+
+    The action handles both registration and sign-in via `upsert? true`.
+    It satisfies the OAuth2 transformer's validation requirements.
+    """
+    @spec add_oauth_register_action(Igniter.t(), module(), atom(), keyword()) :: Igniter.t()
+    # sobelow_skip ["DOS.BinToAtom"]
+    def add_oauth_register_action(igniter, user_resource, strategy_name, opts \\ []) do
+      identity_field = Keyword.get(opts, :identity_field, :email)
+      identity_resource = Keyword.get(opts, :identity_resource)
+
+      identity_change_line =
+        if identity_resource do
+          "change AshAuthentication.Strategy.OAuth2.IdentityChange"
+        else
+          ""
+        end
+
+      Ash.Resource.Igniter.add_new_action(
+        igniter,
+        user_resource,
+        :"register_with_#{strategy_name}",
+        """
+        create :register_with_#{strategy_name} do
+          argument :user_info, :map, allow_nil?: false
+          argument :oauth_tokens, :map, allow_nil?: false
+          upsert? true
+          upsert_identity :unique_#{identity_field}
+
+          change AshAuthentication.GenerateTokenChange
+          #{identity_change_line}
+
+          change fn changeset, _ctx ->
+            user_info = Ash.Changeset.get_argument(changeset, :user_info)
+            Ash.Changeset.change_attribute(changeset, :#{identity_field}, user_info["#{identity_field}"])
+          end
+        end
+        """
+      )
+    end
+
+    @doc """
+    Wires OAuth secrets into the secrets module and runtime.exs.
+
+    For each `{secret_key, env_var_name}` pair:
+    - Adds a `secret_for/4` clause to the secrets module
+    - Adds a `System.get_env` entry to runtime.exs
+    """
+    @spec add_oauth_secrets(
+            Igniter.t(),
+            module(),
+            module(),
+            atom(),
+            list({atom(), String.t()})
+          ) :: Igniter.t()
+    # sobelow_skip ["DOS.StringToAtom"]
+    def add_oauth_secrets(igniter, secrets_module, user_resource, strategy_name, secret_pairs) do
+      otp_app = Igniter.Project.Application.app_name(igniter)
+
+      Enum.reduce(secret_pairs, igniter, fn {secret_key, env_var_name}, igniter ->
+        env_key_atom = String.to_atom(String.downcase(env_var_name))
+
+        runtime_value =
+          {:code,
+           Sourceror.parse_string!("""
+           System.get_env("#{env_var_name}")
+           """)}
+
+        igniter
+        |> add_new_secret_from_env(
+          secrets_module,
+          user_resource,
+          [:authentication, :strategies, strategy_name, secret_key],
+          env_key_atom
+        )
+        |> Igniter.Project.Config.configure(
+          "runtime.exs",
+          otp_app,
+          [env_key_atom],
+          runtime_value
+        )
+      end)
+    end
+
+    defp maybe_set_postgres_table(igniter, resource) do
+      if Code.ensure_loaded?(AshPostgres.DataLayer) do
+        Spark.Igniter.set_option(igniter, resource, [:postgres, :table], "user_identities")
+      else
+        igniter
+      end
+    end
+
+    defp data_layer_extension_args do
+      cond do
+        Code.ensure_loaded?(AshPostgres.DataLayer) -> ["--extend", "postgres"]
+        Code.ensure_loaded?(AshSqlite.DataLayer) -> ["--extend", "sqlite"]
+        true -> []
+      end
+    end
+
     defp enter_section(zipper, name) do
       with {:ok, zipper} <-
              Igniter.Code.Function.move_to_function_call_in_current_scope(

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -252,14 +252,14 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
   defp build_redirect_uri(strategy, context) do
     with {:ok, subject_name} <- Info.authentication_subject_name(strategy.resource),
          {:ok, redirect_uri} <- fetch_secret(strategy, :redirect_uri, context),
-         {:ok, %URI{} = uri} <- URI.new(redirect_uri) do
+         {:ok, %URI{} = uri} <- string_to_uri(redirect_uri) do
       suffix = Path.join([to_string(subject_name), to_string(strategy.name), "callback"])
       # Don't append the path if the secret ends with the path already
       path =
         if String.ends_with?(uri.path, suffix) do
           uri.path
         else
-          Path.join([uri.path || "/", suffix])
+          Path.join([uri.path, suffix])
         end
 
       {:ok, to_string(%URI{uri | path: path})}
@@ -272,6 +272,14 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp string_to_uri(input) when is_binary(input) do
+    case URI.new(input) do
+      {:ok, %URI{path: nil} = uri} -> {:ok, %URI{uri | path: "/"}}
+      {:ok, %URI{} = uri} -> {:ok, uri}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/ash_authentication/strategies/oauth2/user_info_to_attributes.ex
+++ b/lib/ash_authentication/strategies/oauth2/user_info_to_attributes.ex
@@ -11,12 +11,18 @@ defmodule AshAuthentication.Strategy.OAuth2.UserInfoToAttributes do
 
   ## Options
 
-  * `:fields` - a list of attribute atoms to copy from `user_info`. The string key is derived
-    from the atom name. Defaults to `[:email]`.
+  * `:fields` - a list of fields to copy from `user_info`. Each entry can be:
+    * An atom (e.g. `:email`) — maps `"email"` from user_info to the `:email` attribute
+    * A `{source, attribute}` tuple (e.g. `{:email, :user_email}`) — maps `"email"` from
+      user_info to the `:user_email` attribute
 
-  ## Example
+    Defaults to `[:email]`.
+
+  ## Examples
 
       change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email, :name]}
+
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [email: :user_email]}
   """
 
   use Ash.Resource.Change
@@ -26,11 +32,19 @@ defmodule AshAuthentication.Strategy.OAuth2.UserInfoToAttributes do
     fields = opts[:fields] || [:email]
     user_info = Ash.Changeset.get_argument(changeset, :user_info) || %{}
 
-    Enum.reduce(fields, changeset, fn field, changeset ->
-      case Map.get(user_info, to_string(field)) do
+    Enum.reduce(fields, changeset, fn field_spec, changeset ->
+      {source, attribute} = normalize_field(field_spec)
+
+      case Map.get(user_info, to_string(source)) do
         nil -> changeset
-        value -> Ash.Changeset.change_attribute(changeset, field, value)
+        value -> Ash.Changeset.change_attribute(changeset, attribute, value)
       end
     end)
   end
+
+  defp normalize_field({source, attribute}) when is_atom(source) and is_atom(attribute),
+    do: {source, attribute}
+
+  defp normalize_field(field) when is_atom(field),
+    do: {field, field}
 end

--- a/lib/ash_authentication/strategies/oauth2/user_info_to_attributes.ex
+++ b/lib/ash_authentication/strategies/oauth2/user_info_to_attributes.ex
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.Strategy.OAuth2.UserInfoToAttributes do
+  @moduledoc """
+  Sets resource attributes from the `user_info` argument provided by an OAuth2 callback.
+
+  Assent normalises all providers to OpenID Connect standard string-keyed fields
+  (e.g. `"email"`, `"name"`, `"sub"`), so this change works consistently across providers.
+
+  ## Options
+
+  * `:fields` - a list of attribute atoms to copy from `user_info`. The string key is derived
+    from the atom name. Defaults to `[:email]`.
+
+  ## Example
+
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email, :name]}
+  """
+
+  use Ash.Resource.Change
+
+  @impl true
+  def change(changeset, opts, _context) do
+    fields = opts[:fields] || [:email]
+    user_info = Ash.Changeset.get_argument(changeset, :user_info) || %{}
+
+    Enum.reduce(fields, changeset, fn field, changeset ->
+      case Map.get(user_info, to_string(field)) do
+        nil -> changeset
+        value -> Ash.Changeset.change_attribute(changeset, field, value)
+      end
+    end)
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.apple.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.apple.ex
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Apple do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.apple"
+
+    @shortdoc "Adds Apple Sign In authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Apple Sign In uses a private key for authentication instead of a client secret.
+    You will need to generate a key in the Apple Developer portal.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :apple,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(secrets_module, options[:user], :apple, [
+            {:client_id, "APPLE_CLIENT_ID"},
+            {:redirect_uri, "APPLE_REDIRECT_URI"},
+            {:team_id, "APPLE_TEAM_ID"},
+            {:private_key_id, "APPLE_PRIVATE_KEY_ID"},
+            {:private_key_path, "APPLE_PRIVATE_KEY_PATH"}
+          ])
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :apple, :apple, """
+          apple :apple do
+            client_id #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            team_id #{inspect(secrets_module)}
+            private_key_id #{inspect(secrets_module)}
+            private_key_path #{inspect(secrets_module)}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:apple)
+          |> Igniter.add_notice("""
+          Apple Sign In setup:
+
+          1. Go to https://developer.apple.com/account/resources/identifiers/list/serviceId
+          2. Register a Services ID (this is your client_id)
+          3. Enable "Sign In with Apple" and configure the return URL:
+             http://localhost:4000/auth/apple/callback
+          4. Create a key at https://developer.apple.com/account/resources/authkeys/list
+             - Enable "Sign In with Apple"
+             - Download the .p8 key file
+
+          Set these environment variables:
+            APPLE_CLIENT_ID=<your_services_id>
+            APPLE_REDIRECT_URI=http://localhost:4000/auth
+            APPLE_TEAM_ID=<your_team_id>
+            APPLE_PRIVATE_KEY_ID=<your_key_id>
+            APPLE_PRIVATE_KEY_PATH=<path_to_your_.p8_file>
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Apple do
+    @shortdoc "Adds Apple Sign In authentication to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.apple' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.auth0.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.auth0.ex
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Auth0 do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.auth0"
+
+    @shortdoc "Adds Auth0 OAuth authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :auth0,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(secrets_module, options[:user], :auth0, [
+            {:client_id, "AUTH0_CLIENT_ID"},
+            {:client_secret, "AUTH0_CLIENT_SECRET"},
+            {:redirect_uri, "AUTH0_REDIRECT_URI"},
+            {:base_url, "AUTH0_BASE_URL"}
+          ])
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :auth0, :auth0, """
+          auth0 :auth0 do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            base_url #{inspect(secrets_module)}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:auth0)
+          |> Igniter.add_notice("""
+          Auth0 OAuth setup:
+
+          1. Go to https://manage.auth0.com/
+          2. Create a new "Regular Web Application"
+          3. Add http://localhost:4000/auth/auth0/callback to "Allowed Callback URLs"
+
+          Set these environment variables:
+            AUTH0_CLIENT_ID=<your_client_id>
+            AUTH0_CLIENT_SECRET=<your_client_secret>
+            AUTH0_REDIRECT_URI=http://localhost:4000/auth
+            AUTH0_BASE_URL=https://<your-tenant>.auth0.com
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Auth0 do
+    @shortdoc "Adds Auth0 OAuth authentication to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.auth0' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -16,7 +16,15 @@ if Code.ensure_loaded?(Igniter) do
       magic_link: "Register and sign in with a magic link, sent via email to the user.",
       api_key: "Sign in with an API key.",
       totp: "Authenticate with a time-based one-time password (TOTP).",
-      recovery_code: "Authenticate with one-time recovery codes as a 2FA fallback."
+      recovery_code: "Authenticate with one-time recovery codes as a 2FA fallback.",
+      github: "Sign in with GitHub.",
+      google: "Sign in with Google.",
+      apple: "Sign in with Apple.",
+      auth0: "Sign in with Auth0.",
+      microsoft: "Sign in with Microsoft.",
+      slack: "Sign in with Slack.",
+      oidc: "Sign in with a generic OpenID Connect provider.",
+      oauth2: "Sign in with a generic OAuth2 provider."
     ]
 
     @strategy_explanation Enum.map_join(@strategies, "\n", fn {name, description} ->
@@ -30,7 +38,15 @@ if Code.ensure_loaded?(Igniter) do
       "magic_link" => "ash_authentication.add_strategy.magic_link",
       "api_key" => "ash_authentication.add_strategy.api_key",
       "totp" => "ash_authentication.add_strategy.totp",
-      "recovery_code" => "ash_authentication.add_strategy.recovery_code"
+      "recovery_code" => "ash_authentication.add_strategy.recovery_code",
+      "github" => "ash_authentication.add_strategy.github",
+      "google" => "ash_authentication.add_strategy.google",
+      "apple" => "ash_authentication.add_strategy.apple",
+      "auth0" => "ash_authentication.add_strategy.auth0",
+      "microsoft" => "ash_authentication.add_strategy.microsoft",
+      "slack" => "ash_authentication.add_strategy.slack",
+      "oidc" => "ash_authentication.add_strategy.oidc",
+      "oauth2" => "ash_authentication.add_strategy.oauth2"
     }
 
     @moduledoc """
@@ -88,7 +104,12 @@ if Code.ensure_loaded?(Igniter) do
           api_key: :string,
           hash_provider: :string,
           mode: :string,
-          name: :string
+          name: :string,
+          base_url: :string,
+          authorize_url: :string,
+          token_url: :string,
+          user_url: :string,
+          team_id: :string
         ],
         aliases: [
           a: :accounts,

--- a/lib/mix/tasks/ash_authentication.add_strategy.github.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.github.ex
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Github do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.github"
+
+    @shortdoc "Adds GitHub OAuth authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field
+        ],
+        defaults: [
+          identity_field: "email"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :github,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            :github,
+            [
+              {:client_id, "GITHUB_CLIENT_ID"},
+              {:client_secret, "GITHUB_CLIENT_SECRET"},
+              {:redirect_uri, "GITHUB_REDIRECT_URI"}
+            ]
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :github, :github, """
+          github :github do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:github)
+          |> Igniter.add_notice("""
+          GitHub OAuth setup:
+
+          1. Go to https://github.com/settings/developers
+          2. Click "New OAuth App"
+          3. Set the callback URL to: http://localhost:4000/auth/github/callback
+
+          Set these environment variables:
+            GITHUB_CLIENT_ID=<your_client_id>
+            GITHUB_CLIENT_SECRET=<your_client_secret>
+            GITHUB_REDIRECT_URI=http://localhost:4000/auth
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Github do
+    @shortdoc "Adds GitHub OAuth authentication to your user resource"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication.add_strategy.github' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.google.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.google.ex
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Google do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.google"
+
+    @shortdoc "Adds Google OAuth authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :google,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            :google,
+            [
+              {:client_id, "GOOGLE_CLIENT_ID"},
+              {:client_secret, "GOOGLE_CLIENT_SECRET"},
+              {:redirect_uri, "GOOGLE_REDIRECT_URI"}
+            ]
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :google, :google, """
+          google :google do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:google)
+          |> Igniter.add_notice("""
+          Google OAuth setup:
+
+          1. Go to https://console.cloud.google.com/apis/credentials
+          2. Create an OAuth 2.0 Client ID (Web application)
+          3. Add http://localhost:4000/auth/google/callback to "Authorised redirect URIs"
+
+          Set these environment variables:
+            GOOGLE_CLIENT_ID=<your_client_id>
+            GOOGLE_CLIENT_SECRET=<your_client_secret>
+            GOOGLE_REDIRECT_URI=http://localhost:4000/auth
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Google do
+    @shortdoc "Adds Google OAuth authentication to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.google' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.microsoft.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.microsoft.ex
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Microsoft do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.microsoft"
+
+    @shortdoc "Adds Microsoft OAuth authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    By default, the Microsoft strategy uses the "common" tenant endpoint which
+    allows sign-in from any Azure AD tenant. To restrict to a specific tenant,
+    set the `MICROSOFT_BASE_URL` environment variable to
+    `https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0`.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :microsoft,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            :microsoft,
+            [
+              {:client_id, "MICROSOFT_CLIENT_ID"},
+              {:client_secret, "MICROSOFT_CLIENT_SECRET"},
+              {:redirect_uri, "MICROSOFT_REDIRECT_URI"}
+            ]
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(
+            options[:user],
+            :microsoft,
+            :microsoft,
+            """
+            microsoft :microsoft do
+              client_id #{inspect(secrets_module)}
+              client_secret #{inspect(secrets_module)}
+              redirect_uri #{inspect(secrets_module)}
+              identity_resource #{inspect(identity_resource)}
+            end
+            """
+          )
+          |> AshAuthentication.Igniter.codegen_for_strategy(:microsoft)
+          |> Igniter.add_notice("""
+          Microsoft OAuth setup:
+
+          1. Go to https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps
+          2. Register a new application
+          3. Add http://localhost:4000/auth/microsoft/callback to "Redirect URIs"
+          4. Create a client secret under "Certificates & secrets"
+
+          Set these environment variables:
+            MICROSOFT_CLIENT_ID=<your_application_client_id>
+            MICROSOFT_CLIENT_SECRET=<your_client_secret_value>
+            MICROSOFT_REDIRECT_URI=http://localhost:4000/auth
+
+          To restrict to a specific Azure AD tenant, also set:
+            MICROSOFT_BASE_URL=https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Microsoft do
+    @shortdoc "Adds Microsoft OAuth authentication to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.microsoft' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.oauth2.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.oauth2.ex
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Oauth2 do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy oauth2 my_provider"
+
+    @shortdoc "Adds a generic OAuth2 authentication strategy to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Unlike OIDC, generic OAuth2 does not auto-discover provider endpoints.
+    You can provide the URLs via CLI flags (set as literals in the DSL) or
+    leave them to be configured via environment variables.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    * `--base-url` - Base URL of the OAuth2 provider
+    * `--authorize-url` - Authorization endpoint URL (relative to base_url or absolute)
+    * `--token-url` - Token endpoint URL (relative to base_url or absolute)
+    * `--user-url` - User info endpoint URL (relative to base_url or absolute)
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [:name],
+        composes: [],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          base_url: :string,
+          authorize_url: :string,
+          token_url: :string,
+          user_url: :string
+        ],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    # sobelow_skip ["DOS.BinToAtom"]
+    def igniter(igniter) do
+      options = parse_options(igniter)
+      name = String.to_atom(igniter.args.positional[:name])
+      env_prefix = name |> to_string() |> String.upcase()
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          secret_pairs = [
+            {:client_id, "#{env_prefix}_CLIENT_ID"},
+            {:client_secret, "#{env_prefix}_CLIENT_SECRET"},
+            {:redirect_uri, "#{env_prefix}_REDIRECT_URI"}
+          ]
+
+          {url_lines, secret_pairs} =
+            build_url_config(options, secrets_module, env_prefix, secret_pairs)
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            name,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            name,
+            secret_pairs
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :oauth2, name, """
+          oauth2 :#{name} do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            #{url_lines}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(name)
+          |> Igniter.add_notice("""
+          OAuth2 strategy "#{name}" setup:
+
+          Set these environment variables:
+            #{env_prefix}_CLIENT_ID=<your_client_id>
+            #{env_prefix}_CLIENT_SECRET=<your_client_secret>
+            #{env_prefix}_REDIRECT_URI=http://localhost:4000/auth
+          #{url_env_notice(options, env_prefix)}
+          The provider's callback URL should be set to:
+            http://localhost:4000/auth/#{name}/callback
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp build_url_config(options, secrets_module, env_prefix, secret_pairs) do
+      url_fields = [
+        {:base_url, "BASE_URL"},
+        {:authorize_url, "AUTHORIZE_URL"},
+        {:token_url, "TOKEN_URL"},
+        {:user_url, "USER_URL"}
+      ]
+
+      Enum.reduce(url_fields, {"", secret_pairs}, fn {field, env_suffix}, {lines, pairs} ->
+        case Keyword.get(options, field) do
+          nil ->
+            env_var = "#{env_prefix}_#{env_suffix}"
+            line = "#{field} #{inspect(secrets_module)}"
+            {"#{lines}#{line}\n    ", pairs ++ [{field, env_var}]}
+
+          value ->
+            line = "#{field} \"#{value}\""
+            {"#{lines}#{line}\n    ", pairs}
+        end
+      end)
+    end
+
+    defp url_env_notice(options, env_prefix) do
+      [
+        {:base_url, "BASE_URL", "<provider_base_url>"},
+        {:authorize_url, "AUTHORIZE_URL", "<authorize_endpoint>"},
+        {:token_url, "TOKEN_URL", "<token_endpoint>"},
+        {:user_url, "USER_URL", "<user_info_endpoint>"}
+      ]
+      |> Enum.reject(fn {field, _, _} -> Keyword.has_key?(options, field) end)
+      |> Enum.map_join("\n", fn {_, suffix, placeholder} ->
+        "  #{env_prefix}_#{suffix}=#{placeholder}"
+      end)
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Oauth2 do
+    @shortdoc "Adds a generic OAuth2 authentication strategy to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.oauth2' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.oauth2.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.oauth2.ex
@@ -41,12 +41,13 @@ if Code.ensure_loaded?(Igniter) do
         example: @example,
         extra_args?: false,
         only: nil,
-        positional: [:name],
+        positional: [{:name, optional: true}],
         composes: [],
         schema: [
           accounts: :string,
           user: :string,
           identity_field: :string,
+          name: :string,
           base_url: :string,
           authorize_url: :string,
           token_url: :string,
@@ -60,7 +61,22 @@ if Code.ensure_loaded?(Igniter) do
     # sobelow_skip ["DOS.BinToAtom"]
     def igniter(igniter) do
       options = parse_options(igniter)
-      name = String.to_atom(igniter.args.positional[:name])
+
+      name_string = igniter.args.positional[:name] || options[:name]
+
+      unless name_string do
+        raise ArgumentError, """
+        A provider name is required for the generic OAuth2 strategy.
+
+        Via positional argument:
+          mix ash_authentication.add_strategy.oauth2 my_provider
+
+        Via flag:
+          mix ash_authentication.add_strategy oauth2 --name my_provider
+        """
+      end
+
+      name = String.to_atom(name_string)
       env_prefix = name |> to_string() |> String.upcase()
 
       case Igniter.Project.Module.module_exists(igniter, options[:user]) do

--- a/lib/mix/tasks/ash_authentication.add_strategy.oidc.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.oidc.ex
@@ -37,9 +37,15 @@ if Code.ensure_loaded?(Igniter) do
         example: @example,
         extra_args?: false,
         only: nil,
-        positional: [:name],
+        positional: [{:name, optional: true}],
         composes: [],
-        schema: [accounts: :string, user: :string, identity_field: :string, base_url: :string],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          name: :string,
+          base_url: :string
+        ],
         aliases: [a: :accounts, u: :user, i: :identity_field],
         defaults: [identity_field: "email"]
       }
@@ -48,7 +54,22 @@ if Code.ensure_loaded?(Igniter) do
     # sobelow_skip ["DOS.BinToAtom"]
     def igniter(igniter) do
       options = parse_options(igniter)
-      name = String.to_atom(igniter.args.positional[:name])
+
+      name_string = igniter.args.positional[:name] || options[:name]
+
+      unless name_string do
+        raise ArgumentError, """
+        A provider name is required for the generic OIDC strategy.
+
+        Via positional argument:
+          mix ash_authentication.add_strategy.oidc my_provider
+
+        Via flag:
+          mix ash_authentication.add_strategy oidc --name my_provider
+        """
+      end
+
+      name = String.to_atom(name_string)
       env_prefix = name |> to_string() |> String.upcase()
 
       case Igniter.Project.Module.module_exists(igniter, options[:user]) do

--- a/lib/mix/tasks/ash_authentication.add_strategy.oidc.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.oidc.ex
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Oidc do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy oidc my_provider"
+
+    @shortdoc "Adds a generic OpenID Connect authentication strategy to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    OIDC auto-discovers provider endpoints from the `.well-known/openid-configuration`
+    URL, so you only need to provide the base URL of your OIDC provider.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    * `--base-url` - If provided, set as a literal in the strategy DSL instead of via env var
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [:name],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string, base_url: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    # sobelow_skip ["DOS.BinToAtom"]
+    def igniter(igniter) do
+      options = parse_options(igniter)
+      name = String.to_atom(igniter.args.positional[:name])
+      env_prefix = name |> to_string() |> String.upcase()
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          secret_pairs = [
+            {:client_id, "#{env_prefix}_CLIENT_ID"},
+            {:client_secret, "#{env_prefix}_CLIENT_SECRET"},
+            {:redirect_uri, "#{env_prefix}_REDIRECT_URI"}
+          ]
+
+          {base_url_line, secret_pairs} =
+            if options[:base_url] do
+              {"base_url \"#{options[:base_url]}\"", secret_pairs}
+            else
+              {"base_url #{inspect(secrets_module)}",
+               secret_pairs ++ [{:base_url, "#{env_prefix}_BASE_URL"}]}
+            end
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            name,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            name,
+            secret_pairs
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :oidc, name, """
+          oidc :#{name} do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            #{base_url_line}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(name)
+          |> Igniter.add_notice("""
+          OIDC strategy "#{name}" setup:
+
+          Set these environment variables:
+            #{env_prefix}_CLIENT_ID=<your_client_id>
+            #{env_prefix}_CLIENT_SECRET=<your_client_secret>
+            #{env_prefix}_REDIRECT_URI=http://localhost:4000/auth
+          #{unless options[:base_url], do: "  #{env_prefix}_BASE_URL=<your_oidc_provider_base_url>"}
+          The provider's callback URL should be set to:
+            http://localhost:4000/auth/#{name}/callback
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Oidc do
+    @shortdoc "Adds a generic OpenID Connect authentication strategy to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.oidc' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication.add_strategy.slack.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.slack.ex
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Slack do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.slack"
+
+    @shortdoc "Adds Slack OAuth authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--accounts`, `-a` - The accounts domain. Defaults to `YourApp.Accounts`
+    * `--identity-field`, `-i` - The field used to identify the user. Defaults to `email`
+    * `--team-id` - Optional Slack team ID to restrict sign-in to a specific workspace
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [],
+        schema: [accounts: :string, user: :string, identity_field: :string, team_id: :string],
+        aliases: [a: :accounts, u: :user, i: :identity_field],
+        defaults: [identity_field: "email"]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          identity_resource =
+            Module.concat(AshAuthentication.Igniter.parent_module(options[:user]), UserIdentity)
+
+          secrets_module = Igniter.Project.Module.module_name(igniter, "Secrets")
+
+          secret_pairs = [
+            {:client_id, "SLACK_CLIENT_ID"},
+            {:client_secret, "SLACK_CLIENT_SECRET"},
+            {:redirect_uri, "SLACK_REDIRECT_URI"}
+          ]
+
+          secret_pairs =
+            if options[:team_id] do
+              secret_pairs ++ [{:team_id, "SLACK_TEAM_ID"}]
+            else
+              secret_pairs
+            end
+
+          team_id_line =
+            if options[:team_id] do
+              "team_id #{inspect(secrets_module)}"
+            else
+              ""
+            end
+
+          igniter
+          |> Ash.Resource.Igniter.add_new_attribute(options[:user], options[:identity_field], """
+          attribute #{inspect(options[:identity_field])}, :ci_string do
+            allow_nil? false
+            public? true
+          end
+          """)
+          |> AshAuthentication.Igniter.ensure_identity(options[:user], options[:identity_field])
+          |> AshAuthentication.Igniter.ensure_user_identity_resource(
+            options[:user],
+            identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_register_action(
+            options[:user],
+            :slack,
+            identity_field: options[:identity_field],
+            identity_resource: identity_resource
+          )
+          |> AshAuthentication.Igniter.add_oauth_secrets(
+            secrets_module,
+            options[:user],
+            :slack,
+            secret_pairs
+          )
+          |> AshAuthentication.Igniter.add_new_strategy(options[:user], :slack, :slack, """
+          slack :slack do
+            client_id #{inspect(secrets_module)}
+            client_secret #{inspect(secrets_module)}
+            redirect_uri #{inspect(secrets_module)}
+            #{team_id_line}
+            identity_resource #{inspect(identity_resource)}
+          end
+          """)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:slack)
+          |> Igniter.add_notice("""
+          Slack OAuth setup:
+
+          1. Go to https://api.slack.com/apps
+          2. Create a new app (or select an existing one)
+          3. Under "OAuth & Permissions", add http://localhost:4000/auth/slack/callback to "Redirect URLs"
+
+          Set these environment variables:
+            SLACK_CLIENT_ID=<your_client_id>
+            SLACK_CLIENT_SECRET=<your_client_secret>
+            SLACK_REDIRECT_URI=http://localhost:4000/auth
+          """)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn -> Module.concat(options[:accounts], User) end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Slack do
+    @shortdoc "Adds Slack OAuth authentication to your user resource"
+    @moduledoc @shortdoc
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("The task 'ash_authentication.add_strategy.slack' requires igniter.")
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -202,10 +202,7 @@ actions do
     # If UserIdentity resource is being used
     change AshAuthentication.Strategy.OAuth2.IdentityChange
 
-    change fn changeset, _ctx ->
-      user_info = Ash.Changeset.get_argument(changeset, :user_info)
-      Ash.Changeset.change_attributes(changeset, Map.take(user_info, ["email"]))
-    end
+    change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email]}
   end
 end
 ```
@@ -320,13 +317,7 @@ actions do
     upsert_identity :email
 
     change AshAuthentication.GenerateTokenChange
-    change fn changeset, _ctx ->
-      user_info = Ash.Changeset.get_argument(changeset, :user_info)
-
-      changeset
-      |> Ash.Changeset.change_attribute(:email, user_info["email"])
-      |> Ash.Changeset.change_attribute(:name, user_info["name"])
-    end
+    change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [:email, :name]}
   end
 end
 ```


### PR DESCRIPTION
## Summary

- Adds `mix ash_authentication.add_strategy` support for all 8 OAuth/OIDC strategies: `github`, `google`, `apple`, `auth0`, `microsoft`, `slack`, `oidc` (generic), `oauth2` (generic)
- Each generator creates the UserIdentity resource, register action, strategy DSL, secrets wiring, and prints provider-specific setup instructions
- New shared helpers in `AshAuthentication.Igniter`: `ensure_user_identity_resource/3`, `add_oauth_register_action/4`, `add_oauth_secrets/5`
- Secrets are wired via `System.get_env` in `runtime.exs` (works in all environments)

Companion PR for ash_authentication_phoenix: extracts sign-in infrastructure into a composable `ash_authentication_phoenix.setup` task and registers OAuth strategies in the AAP dispatcher.

## Test plan

- [x] All 63 existing igniter tests pass
- [x] Compiles cleanly with `--warnings-as-errors`
- [ ] Manual test: `mix ash_authentication.add_strategy github` on a fresh project
- [ ] Manual test: `mix ash_authentication.add_strategy oidc keycloak --base-url https://kc.example.com`
- [ ] Manual test: adding two providers to the same resource (UserIdentity reuse)