### PR TITLE
fix: remove dup migration name in password strategy and standardise

### DIFF
--- a/lib/ash_authentication/igniter.ex
+++ b/lib/ash_authentication/igniter.ex
@@ -347,6 +347,19 @@ if Code.ensure_loaded?(Igniter) do
     def maybe_parse_module(string) when is_binary(string),
       do: Igniter.Project.Module.parse(string)
 
+    @doc """
+    Runs `Ash.Igniter.codegen/2` with a consistent migration name for a strategy.
+
+    ## Example
+
+        codegen_for_strategy(igniter, :password)
+        # => codegen named "add_password_auth_strategy"
+    """
+    @spec codegen_for_strategy(Igniter.t(), atom()) :: Igniter.t()
+    def codegen_for_strategy(igniter, strategy_name) do
+      Ash.Igniter.codegen(igniter, "add_#{strategy_name}_auth_strategy")
+    end
+
     defp enter_section(zipper, name) do
       with {:ok, zipper} <-
              Igniter.Code.Function.move_to_function_call_in_current_scope(

--- a/lib/mix/tasks/ash_authentication.add_strategy.api_key.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.api_key.ex
@@ -53,7 +53,7 @@ if Code.ensure_loaded?(Igniter) do
         {true, igniter} ->
           igniter
           |> api_key(options)
-          |> Ash.Igniter.codegen("add_api_key_auth")
+          |> AshAuthentication.Igniter.codegen_for_strategy(:api_key)
 
         {false, igniter} ->
           Igniter.add_issue(igniter, """

--- a/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.magic_link.ex
@@ -68,7 +68,7 @@ if Code.ensure_loaded?(Igniter) do
           igniter
           |> magic_link(options)
           |> AshAuthentication.Igniter.add_remember_me_strategy(options[:user])
-          |> Ash.Igniter.codegen("add_magic_link_auth")
+          |> AshAuthentication.Igniter.codegen_for_strategy(:magic_link)
 
         {false, igniter} ->
           Igniter.add_issue(igniter, """

--- a/lib/mix/tasks/ash_authentication.add_strategy.password.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.password.ex
@@ -63,7 +63,7 @@ if Code.ensure_loaded?(Igniter) do
           igniter
           |> password(options)
           |> AshAuthentication.Igniter.add_remember_me_strategy(options[:user])
-          |> Ash.Igniter.codegen("add_password_auth")
+          |> AshAuthentication.Igniter.codegen_for_strategy(:password)
 
         {false, igniter} ->
           Igniter.add_issue(igniter, """
@@ -181,7 +181,6 @@ if Code.ensure_loaded?(Igniter) do
       |> generate_sign_in_and_registration(options)
       |> generate_reset(sender, options)
       |> add_confirmation(options)
-      |> Ash.Igniter.codegen("add_password_authentication")
     end
 
     defp add_confirmation(igniter, options) do

--- a/lib/mix/tasks/ash_authentication.add_strategy.recovery_code.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.recovery_code.ex
@@ -60,7 +60,7 @@ if Code.ensure_loaded?(Igniter) do
         {true, igniter} ->
           igniter
           |> add_recovery_code_resource(options)
-          |> Ash.Igniter.codegen("add_recovery_code_auth")
+          |> AshAuthentication.Igniter.codegen_for_strategy(:recovery_code)
 
         {false, igniter} ->
           Igniter.add_issue(igniter, """

--- a/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.totp.ex
@@ -89,7 +89,7 @@ if Code.ensure_loaded?(Igniter) do
         {true, igniter} ->
           igniter
           |> totp(options)
-          |> Ash.Igniter.codegen("add_totp_auth")
+          |> AshAuthentication.Igniter.codegen_for_strategy(:totp)
 
         {false, igniter} ->
           Igniter.add_issue(igniter, """

--- a/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy.totp_test.exs
@@ -24,6 +24,13 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategy.TotpTest do
   end
 
   describe "2fa mode (default)" do
+    test "generates a migration named with add_totp_auth_strategy suffix", %{igniter: igniter} do
+      # TOTP composes the audit_log add-on, so the combined codegen name includes both
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])
+      |> assert_has_task("ash.codegen", ["add_audit_log_and_add_totp_auth_strategy"])
+    end
+
     test "adds totp_secret attribute to the user", %{igniter: igniter} do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy.totp", [])

--- a/test/mix/tasks/ash_authentication.add_strategy_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy_test.exs
@@ -344,6 +344,12 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
       """)
     end
 
+    test "generates a migration named add_password_auth_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
+      |> assert_has_task("ash.codegen", ["add_password_auth_strategy"])
+    end
+
     test "creates a basic password reset sender", %{igniter: igniter} do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
@@ -369,6 +375,12 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
   end
 
   describe "api_key" do
+    test "generates a migration named add_api_key_auth_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["api_key"])
+      |> assert_has_task("ash.codegen", ["add_api_key_auth_strategy"])
+    end
+
     test "adds the api_key strategy to the user", %{igniter: igniter} do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy", ["api_key"])
@@ -450,6 +462,14 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategyTest do
   end
 
   describe "magic_link" do
+    test "generates a migration named add_magic_link_auth_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
+      |> apply_igniter!()
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["magic_link"])
+      |> assert_has_task("ash.codegen", ["add_magic_link_auth_strategy"])
+    end
+
     test "makes hashed_password optional", %{igniter: igniter} do
       igniter
       |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])


### PR DESCRIPTION
The password strategy's `password/2` function called `Ash.Igniter.codegen("add_password_authentication")` internally, and then `igniter/0` called it again with `"add_password_auth"`. 

Since `Ash.Igniter.codegen/2` appends `_and_<name>` when a task already exists, this produced the duplicated migration name `add_password_authentication_and_add_password_auth`.

Extracts `AshAuthentication.Igniter.codegen_for_strategy/2` to centralize migration naming with a consistent `add_<strategy>_auth_strategy` pattern across all strategies. Adds test assertions for migration names.