### PR TITLE
fix: use conn remote ip over peer data

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
+++ b/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
@@ -27,6 +27,20 @@ defmodule MyApp.Accounts.User do
 end
 ```
 
+## Request remote IP configuration
+
+Audit log request metadata stores `remote_ip` from
+`Plug.Conn.get_peer_data(conn).address` by default.
+
+If your app is behind trusted proxy middleware that has already normalized
+`conn.remote_ip`, you can opt in to using that value instead:
+
+`config :ash_authentication, request_remote_ip_source: :conn`
+
+Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when
+your Plug/Phoenix app has a trusted proxy or IP normalization setup that
+rewrites `conn.remote_ip` from trusted headers.
+
 
 
 ### authentication.add_ons.audit_log

--- a/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
+++ b/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
@@ -27,19 +27,8 @@ defmodule MyApp.Accounts.User do
 end
 ```
 
-## Request remote IP configuration
-
-Audit log request metadata stores `remote_ip` from
-`Plug.Conn.get_peer_data(conn).address` by default.
-
-If your app is behind trusted proxy middleware that has already normalized
-`conn.remote_ip`, you can opt in to using that value instead:
-
-`config :ash_authentication, request_remote_ip_source: :conn`
-
-Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when
-your Plug/Phoenix app has a trusted proxy or IP normalization setup that
-rewrites `conn.remote_ip` from trusted headers.
+Request metadata uses `conn.remote_ip` for `remote_ip`, so proxy-aware plugs
+can rewrite it from forwarded/proxy metadata before AshAuthentication runs.
 
 
 

--- a/documentation/tutorials/audit-log.md
+++ b/documentation/tutorials/audit-log.md
@@ -352,6 +352,18 @@ The IP privacy transformation applies to all IP-related fields in the request me
 - `x_forwarded_for` - Proxy chain IPs
 - `forwarded` - Standard forwarded header with IP information
 
+### Configure IP address source
+By default, `remote_ip` comes from `Plug.Conn.get_peer_data(conn).address`. If your app is behind trusted proxy middleware that has already
+ normalized `conn.remote_ip`, you can opt in to using that value instead:
+
+```elixir
+config :ash_authentication, request_remote_ip_source: :conn
+```
+
+Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when your 
+Plug/Phoenix app has a trusted proxy or IP normalization setup that rewrites 
+`conn.remote_ip` from trusted headers.
+
 ## Audit log attributes
 
 Each audit log entry contains:

--- a/documentation/tutorials/audit-log.md
+++ b/documentation/tutorials/audit-log.md
@@ -352,18 +352,6 @@ The IP privacy transformation applies to all IP-related fields in the request me
 - `x_forwarded_for` - Proxy chain IPs
 - `forwarded` - Standard forwarded header with IP information
 
-### Configure IP address source
-By default, `remote_ip` comes from `Plug.Conn.get_peer_data(conn).address`. If your app is behind trusted proxy middleware that has already
- normalized `conn.remote_ip`, you can opt in to using that value instead:
-
-```elixir
-config :ash_authentication, request_remote_ip_source: :conn
-```
-
-Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when your 
-Plug/Phoenix app has a trusted proxy or IP normalization setup that rewrites 
-`conn.remote_ip` from trusted headers.
-
 ## Audit log attributes
 
 Each audit log entry contains:
@@ -378,7 +366,9 @@ Each audit log entry contains:
 - `extra_data` - Additional information including:
   - `actor` - The actor performing the action (if any)
   - `tenant` - The tenant context (if using multi-tenancy)
-  - `request` - Request metadata
+  - `request` - Request metadata. `remote_ip` is taken from `conn.remote_ip`,
+    so proxy-aware plugs can rewrite it from forwarded/proxy metadata before
+    AshAuthentication runs
   - `params` - Non-sensitive parameters from the action
 - `resource` - The resource module that was authenticated
 

--- a/lib/ash_authentication/add_ons/audit_log.ex
+++ b/lib/ash_authentication/add_ons/audit_log.ex
@@ -28,19 +28,8 @@ defmodule AshAuthentication.AddOn.AuditLog do
   end
   ```
 
-  ## Request remote IP configuration
-
-  Audit log request metadata stores `remote_ip` from
-  `Plug.Conn.get_peer_data(conn).address` by default.
-
-  If your app is behind trusted proxy middleware that has already normalized
-  `conn.remote_ip`, you can opt in to using that value instead:
-
-  `config :ash_authentication, request_remote_ip_source: :conn`
-
-  Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when
-  your Plug/Phoenix app has a trusted proxy or IP normalization setup that
-  rewrites `conn.remote_ip` from trusted headers.
+  Request metadata uses `conn.remote_ip` for `remote_ip`, so proxy-aware plugs
+  can rewrite it from forwarded/proxy metadata before AshAuthentication runs.
   """
 
   defstruct audit_log_resource: nil,

--- a/lib/ash_authentication/add_ons/audit_log.ex
+++ b/lib/ash_authentication/add_ons/audit_log.ex
@@ -27,6 +27,20 @@ defmodule AshAuthentication.AddOn.AuditLog do
     end
   end
   ```
+
+  ## Request remote IP configuration
+
+  Audit log request metadata stores `remote_ip` from
+  `Plug.Conn.get_peer_data(conn).address` by default.
+
+  If your app is behind trusted proxy middleware that has already normalized
+  `conn.remote_ip`, you can opt in to using that value instead:
+
+  `config :ash_authentication, request_remote_ip_source: :conn`
+
+  Supported values are `:peer_data` (default) and `:conn`. Only use `:conn` when
+  your Plug/Phoenix app has a trusted proxy or IP normalization setup that
+  rewrites `conn.remote_ip` from trusted headers.
   """
 
   defstruct audit_log_resource: nil,

--- a/lib/ash_authentication/plug/dispatcher.ex
+++ b/lib/ash_authentication/plug/dispatcher.ex
@@ -77,7 +77,7 @@ defmodule AshAuthentication.Plug.Dispatcher do
 
     request_context = %{
       ash_authentication_request: %{
-        remote_ip: request_remote_ip(conn, peer_data),
+        remote_ip: format_ip(conn.remote_ip),
         remote_port: peer_data.port,
         http_host: conn.host,
         http_method: conn.method,
@@ -88,13 +88,6 @@ defmodule AshAuthentication.Plug.Dispatcher do
 
     existing_context = Ash.PlugHelpers.get_context(conn) || %{}
     Ash.PlugHelpers.set_context(conn, Map.merge(existing_context, request_context))
-  end
-
-  defp request_remote_ip(conn, peer_data) do
-    case Application.get_env(:ash_authentication, :request_remote_ip_source) || :peer_data do
-      :peer_data -> format_ip(peer_data.address)
-      :conn -> format_ip(conn.remote_ip)
-    end
   end
 
   defp format_ip(ip), do: ip |> :inet.ntoa() |> to_string()

--- a/lib/ash_authentication/plug/dispatcher.ex
+++ b/lib/ash_authentication/plug/dispatcher.ex
@@ -77,7 +77,7 @@ defmodule AshAuthentication.Plug.Dispatcher do
 
     request_context = %{
       ash_authentication_request: %{
-        remote_ip: peer_data.address |> :inet.ntoa() |> to_string(),
+        remote_ip: request_remote_ip(conn, peer_data),
         remote_port: peer_data.port,
         http_host: conn.host,
         http_method: conn.method,
@@ -89,4 +89,13 @@ defmodule AshAuthentication.Plug.Dispatcher do
     existing_context = Ash.PlugHelpers.get_context(conn) || %{}
     Ash.PlugHelpers.set_context(conn, Map.merge(existing_context, request_context))
   end
+
+  defp request_remote_ip(conn, peer_data) do
+    case Application.get_env(:ash_authentication, :request_remote_ip_source) || :peer_data do
+      :peer_data -> format_ip(peer_data.address)
+      :conn -> format_ip(conn.remote_ip)
+    end
+  end
+
+  defp format_ip(ip), do: ip |> :inet.ntoa() |> to_string()
 end

--- a/test/ash_authentication/plug/dispatcher_test.exs
+++ b/test/ash_authentication/plug/dispatcher_test.exs
@@ -9,25 +9,14 @@ defmodule AshAuthentication.Plug.DispatcherTest do
 
   import Plug.Test, only: [conn: 3, put_peer_data: 2]
 
-  setup do
-    original_request_remote_ip_source =
-      Application.get_env(:ash_authentication, :request_remote_ip_source)
-
-    on_exit(fn ->
-      Application.put_env(
-        :ash_authentication,
-        :request_remote_ip_source,
-        original_request_remote_ip_source
-      )
-    end)
-
-    :ok
-  end
-
   describe "request context" do
-    test "preserves existing context" do
+    setup do
+      [conn: conn(:post, "/auth/user/password/sign_in_with_token ", %{})]
+    end
+
+    test "preserves existing context", %{conn: conn} do
       context =
-        conn_with_remote_ips()
+        conn
         |> Ash.PlugHelpers.set_context(%{existing: "context"})
         |> dispatch()
         |> Ash.PlugHelpers.get_context()
@@ -36,34 +25,16 @@ defmodule AshAuthentication.Plug.DispatcherTest do
       assert Map.has_key?(context, :ash_authentication_request)
     end
 
-    test "defaults to peer data for remote_ip" do
-      Application.delete_env(:ash_authentication, :request_remote_ip_source)
-
+    test "formats conn's remote_ip over peer_data", %{conn: conn} do
       context =
-        conn_with_remote_ips()
-        |> dispatch()
-        |> Ash.PlugHelpers.get_context()
-
-      assert context.ash_authentication_request.remote_ip == "192.0.2.34"
-    end
-
-    test "uses conn.remote_ip when request_remote_ip_source is configured as :conn" do
-      Application.put_env(:ash_authentication, :request_remote_ip_source, :conn)
-
-      context =
-        conn_with_remote_ips()
+        conn
+        |> Map.put(:remote_ip, {203, 0, 113, 56})
+        |> put_peer_data(%{address: {192, 0, 2, 34}, port: 40_000})
         |> dispatch()
         |> Ash.PlugHelpers.get_context()
 
       assert context.ash_authentication_request.remote_ip == "203.0.113.56"
     end
-  end
-
-  defp conn_with_remote_ips do
-    :post
-    |> conn("/auth/user/password/sign_in_with_token ", %{})
-    |> Map.put(:remote_ip, {203, 0, 113, 56})
-    |> put_peer_data(%{address: {192, 0, 2, 34}, port: 40_000})
   end
 
   defp dispatch(conn) do

--- a/test/ash_authentication/plug/dispatcher_test.exs
+++ b/test/ash_authentication/plug/dispatcher_test.exs
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.Plug.DispatcherTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  alias AshAuthentication.Plug.Dispatcher
+
+  import Plug.Test, only: [conn: 3, put_peer_data: 2]
+
+  setup do
+    original_request_remote_ip_source =
+      Application.get_env(:ash_authentication, :request_remote_ip_source)
+
+    on_exit(fn ->
+      Application.put_env(
+        :ash_authentication,
+        :request_remote_ip_source,
+        original_request_remote_ip_source
+      )
+    end)
+
+    :ok
+  end
+
+  describe "request context" do
+    test "preserves existing context" do
+      context =
+        conn_with_remote_ips()
+        |> Ash.PlugHelpers.set_context(%{existing: "context"})
+        |> dispatch()
+        |> Ash.PlugHelpers.get_context()
+
+      assert context.existing == "context"
+      assert Map.has_key?(context, :ash_authentication_request)
+    end
+
+    test "defaults to peer data for remote_ip" do
+      Application.delete_env(:ash_authentication, :request_remote_ip_source)
+
+      context =
+        conn_with_remote_ips()
+        |> dispatch()
+        |> Ash.PlugHelpers.get_context()
+
+      assert context.ash_authentication_request.remote_ip == "192.0.2.34"
+    end
+
+    test "uses conn.remote_ip when request_remote_ip_source is configured as :conn" do
+      Application.put_env(:ash_authentication, :request_remote_ip_source, :conn)
+
+      context =
+        conn_with_remote_ips()
+        |> dispatch()
+        |> Ash.PlugHelpers.get_context()
+
+      assert context.ash_authentication_request.remote_ip == "203.0.113.56"
+    end
+  end
+
+  defp conn_with_remote_ips do
+    :post
+    |> conn("/auth/user/password/sign_in_with_token ", %{})
+    |> Map.put(:remote_ip, {203, 0, 113, 56})
+    |> put_peer_data(%{address: {192, 0, 2, 34}, port: 40_000})
+  end
+
+  defp dispatch(conn) do
+    Dispatcher.call(
+      conn,
+      {:sign_in_with_token, AshAuthentication.Info.strategy!(Example.User, :password),
+       AshAuthentication.Plug.Defaults}
+    )
+  end
+end

--- a/test/ash_authentication/plug/dispatcher_test.exs
+++ b/test/ash_authentication/plug/dispatcher_test.exs
@@ -4,7 +4,7 @@
 
 defmodule AshAuthentication.Plug.DispatcherTest do
   @moduledoc false
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias AshAuthentication.Plug.Dispatcher
 
   import Plug.Test, only: [conn: 3, put_peer_data: 2]


### PR DESCRIPTION
Hello! Thanks again for all the great work here.

This is my proposed fix for https://github.com/team-alembic/ash_authentication/issues/1155. It gives those of us running `RemoteIp` the option to use the `conn.remote_ip` directly so that we record actual client IP addresses in audit logs.