### PR TITLE
feat: add igniter generator for OTP strategy

### DIFF
--- a/lib/mix/tasks/ash_authentication.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.ex
@@ -14,6 +14,7 @@ if Code.ensure_loaded?(Igniter) do
     @strategies [
       password: "Register and sign in with a username/email and a password.",
       magic_link: "Register and sign in with a magic link, sent via email to the user.",
+      otp: "Sign in with a short one-time password sent via email or SMS.",
       api_key: "Sign in with an API key.",
       totp: "Authenticate with a time-based one-time password (TOTP).",
       recovery_code: "Authenticate with one-time recovery codes as a 2FA fallback.",
@@ -36,6 +37,7 @@ if Code.ensure_loaded?(Igniter) do
     @strategy_tasks %{
       "password" => "ash_authentication.add_strategy.password",
       "magic_link" => "ash_authentication.add_strategy.magic_link",
+      "otp" => "ash_authentication.add_strategy.otp",
       "api_key" => "ash_authentication.add_strategy.api_key",
       "totp" => "ash_authentication.add_strategy.totp",
       "recovery_code" => "ash_authentication.add_strategy.recovery_code",
@@ -62,6 +64,7 @@ if Code.ensure_loaded?(Igniter) do
 
       * `mix ash_authentication.add_strategy.password`
       * `mix ash_authentication.add_strategy.magic_link`
+      * `mix ash_authentication.add_strategy.otp`
       * `mix ash_authentication.add_strategy.api_key`
       * `mix ash_authentication.add_strategy.totp`
 

--- a/lib/mix/tasks/ash_authentication.add_strategy.otp.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.otp.ex
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Otp do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication.add_strategy.otp"
+
+    @shortdoc "Adds one-time password (OTP) authentication to your user resource"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Adds the OTP strategy to your user resource — passwordless authentication
+    via a short code (e.g. `XKPTMH`) sent via email or SMS.
+
+    Brute-force protection is required by the strategy. By default this task
+    composes an `audit_log` add-on (creating one if it doesn't already exist)
+    and wires `brute_force_strategy {:audit_log, :audit_log}` into the
+    strategy.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--identity-field`, `-i` - The field on the user resource that will be
+      used to identify the user. Defaults to `email`
+    * `--name`, `-n` - The name of the OTP strategy. Defaults to `otp`.
+
+    ## Notes
+
+    `registration_enabled?: true` (sign-in becomes an upsert) is not currently
+    supported by this task because the verifier forbids the `:audit_log`
+    brute-force strategy in registration mode, and the alternatives
+    (`:rate_limit` or `{:preparation, ...}`) require user-supplied
+    configuration. Add the strategy by hand and follow the OTP tutorial if you
+    need that mode.
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [
+          "ash_authentication.add_add_on.audit_log"
+        ],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          name: :string,
+          registration: :boolean
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field,
+          n: :name
+        ],
+        defaults: [
+          identity_field: "email",
+          name: "otp"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      if options[:registration] do
+        Mix.shell().error("""
+        `--registration` is not supported by this task.
+
+        When `registration_enabled?` is true, the OTP strategy cannot use the
+        `:audit_log` brute-force strategy (the verifier rejects it). The
+        alternatives are `:rate_limit` (requires the AshRateLimiter extension
+        and a backend) or `{:preparation, MyMod}` (requires you to write a
+        preparation module). Both need decisions this generator can't make
+        safely on your behalf.
+
+        Add the OTP strategy by hand and follow the OTP tutorial:
+        https://hexdocs.pm/ash_authentication/otp.html
+        """)
+
+        exit({:shutdown, 1})
+      end
+
+      case Igniter.Project.Module.module_exists(igniter, options[:user]) do
+        {true, igniter} ->
+          igniter
+          |> otp(options)
+          |> AshAuthentication.Igniter.codegen_for_strategy(:otp)
+
+        {false, igniter} ->
+          Igniter.add_issue(igniter, """
+          User module #{inspect(options[:user])} was not found.
+
+          Perhaps you have not yet installed ash_authentication?
+          """)
+      end
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update(:name, :otp, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &AshAuthentication.Igniter.maybe_parse_module/1)
+      |> Keyword.update!(:user, &AshAuthentication.Igniter.maybe_parse_module/1)
+    end
+
+    # sobelow_skip ["DOS.BinToAtom"]
+    defp otp(igniter, options) do
+      sender = Module.concat(options[:user], Senders.SendOtp)
+      strategy_name = options[:name]
+      identity_field = options[:identity_field]
+      request_action = :"request_#{strategy_name}"
+      sign_in_action = :"sign_in_with_#{strategy_name}"
+
+      igniter
+      |> Ash.Resource.Igniter.add_new_attribute(options[:user], identity_field, """
+      attribute #{inspect(identity_field)}, :ci_string do
+        allow_nil? false
+        public? true
+      end
+      """)
+      |> AshAuthentication.Igniter.ensure_identity(options[:user], identity_field)
+      |> AshAuthentication.Igniter.ensure_get_by_action(options[:user], identity_field)
+      |> compose_audit_log(options)
+      |> Ash.Resource.Igniter.add_new_action(options[:user], request_action, """
+      action #{inspect(request_action)} do
+        argument #{inspect(identity_field)}, :ci_string do
+          allow_nil? false
+          description "The identity to send a one-time password to."
+        end
+
+        run AshAuthentication.Strategy.Otp.Request
+        description "Send a one-time password to a user if they exist."
+      end
+      """)
+      |> Ash.Resource.Igniter.add_new_action(options[:user], sign_in_action, """
+      read #{inspect(sign_in_action)} do
+        description "Sign in a user with a one-time password."
+        get? true
+
+        argument #{inspect(identity_field)}, :ci_string do
+          allow_nil? false
+        end
+
+        argument :otp, :string do
+          allow_nil? false
+          sensitive? true
+        end
+
+        prepare AshAuthentication.Strategy.Otp.SignInPreparation
+
+        metadata :token, :string do
+          allow_nil? false
+        end
+      end
+      """)
+      |> AshAuthentication.Igniter.add_new_strategy(
+        options[:user],
+        :otp,
+        strategy_name,
+        """
+        otp #{inspect(strategy_name)} do
+          identity_field #{inspect(identity_field)}
+          brute_force_strategy {:audit_log, :audit_log}
+          sender #{inspect(sender)}
+        end
+        """
+      )
+      |> create_new_otp_sender(sender, options)
+    end
+
+    defp compose_audit_log(igniter, options) do
+      {igniter, has_audit_log?} =
+        AshAuthentication.Igniter.defines_add_on(igniter, options[:user], :audit_log, nil)
+
+      if has_audit_log? do
+        igniter
+      else
+        Igniter.compose_task(
+          igniter,
+          "ash_authentication.add_add_on.audit_log",
+          ["--user", inspect(options[:user])]
+        )
+      end
+    end
+
+    defp create_new_otp_sender(igniter, sender, _options) do
+      Igniter.Project.Module.create_module(
+        igniter,
+        sender,
+        ~s'''
+        @moduledoc """
+        Sends a one-time password code to the user.
+        """
+
+        use AshAuthentication.Sender
+
+        @impl true
+        def send(user, otp_code, _opts) do
+          # The `user` argument is the user record matching the identity that
+          # was submitted. The `otp_code` is the short code that should be
+          # sent to them — typically by email or SMS.
+
+          IO.puts("""
+          Hello, \#{user.email}! Your sign-in code is:
+
+              \#{otp_code}
+
+          This code expires in 10 minutes.
+          """)
+        end
+        ''',
+        on_exists: :warning
+      )
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthentication.AddStrategy.Otp do
+    @shortdoc "Adds one-time password (OTP) authentication to your user resource"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication.add_strategy.otp' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/mix/tasks/ash_authentication.add_strategy.otp_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy.otp_test.exs
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Mix.Tasks.AshAuthentication.AddStrategy.OtpTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  setup do
+    igniter =
+      test_project()
+      |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+      |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+      # These can be removed when https://github.com/hrzndhrn/rewrite/issues/39 is addressed (in igniter too)
+      |> Igniter.Project.Formatter.remove_imported_dep(:ash_authentication)
+      |> Igniter.Project.Formatter.remove_formatter_plugin(Spark.Formatter)
+      |> apply_igniter!()
+
+    [igniter: igniter]
+  end
+
+  describe "default invocation" do
+    test "generates a migration named with add_otp_auth_strategy suffix", %{igniter: igniter} do
+      # OTP composes the audit_log add-on, so the combined codegen name includes both
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_task("ash.codegen", ["add_audit_log_and_add_otp_auth_strategy"])
+    end
+
+    test "adds the otp strategy block", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :otp do
+      + |      identity_field(:email)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+
+    test "adds the identity field attribute", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    attribute :email, :ci_string do
+      + |      allow_nil?(false)
+      + |      public?(true)
+      + |    end
+      """)
+    end
+
+    test "ensures a unique identity for the identity field", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |  identities do
+      + |    identity(:unique_email, [:email])
+      + |  end
+      """)
+    end
+
+    test "adds a get_by lookup action", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    read :get_by_email do
+      + |      description("Looks up a user by their email")
+      + |      get_by(:email)
+      + |    end
+      """)
+    end
+
+    test "adds a request_otp action", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    action :request_otp do
+      + |      argument :email, :ci_string do
+      + |        allow_nil?(false)
+      + |        description("The identity to send a one-time password to.")
+      + |      end
+      + |
+      + |      run(AshAuthentication.Strategy.Otp.Request)
+      + |      description("Send a one-time password to a user if they exist.")
+      + |    end
+      """)
+    end
+
+    test "adds a sign_in_with_otp action", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    read :sign_in_with_otp do
+      + |      description("Sign in a user with a one-time password.")
+      + |      get?(true)
+      + |
+      + |      argument :email, :ci_string do
+      + |        allow_nil?(false)
+      + |      end
+      + |
+      + |      argument :otp, :string do
+      + |        allow_nil?(false)
+      + |        sensitive?(true)
+      + |      end
+      + |
+      + |      prepare(AshAuthentication.Strategy.Otp.SignInPreparation)
+      + |
+      + |      metadata :token, :string do
+      + |        allow_nil?(false)
+      + |      end
+      + |    end
+      """)
+    end
+
+    test "composes the audit_log add-on", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |      audit_log do
+      + |        audit_log_resource(Test.Accounts.AuditLog)
+      + |      end
+      """)
+    end
+
+    test "creates the audit_log resource", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_creates("lib/test/accounts/audit_log.ex")
+    end
+
+    test "creates the SendOtp sender module", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_creates("lib/test/accounts/user/senders/send_otp.ex")
+    end
+  end
+
+  describe "via parent task" do
+    test "can be invoked via ash_authentication.add_strategy", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy", ["otp"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :otp do
+      + |      identity_field(:email)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+  end
+
+  describe "custom options" do
+    test "supports custom strategy name", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", ["--name", "email_otp"])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :email_otp do
+      + |      identity_field(:email)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+
+    test "supports custom identity field", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [
+        "--identity-field",
+        "username"
+      ])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :otp do
+      + |      identity_field(:username)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+  end
+
+  describe "error handling" do
+    test "shows error for missing user resource", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [
+        "--user",
+        "NonExistent.User"
+      ])
+      |> assert_has_issue(&String.contains?(&1, "User module NonExistent.User was not found"))
+    end
+  end
+
+  describe "idempotency" do
+    test "does not duplicate audit log add-on when already present", %{igniter: igniter} do
+      igniter =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_add_on", ["audit_log"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :otp do
+      + |      identity_field(:email)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+  end
+
+  describe "combination with password strategy" do
+    test "can add otp after password", %{igniter: igniter} do
+      igniter =
+        igniter
+        |> Igniter.compose_task("ash_authentication.add_strategy", ["password"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.otp", [])
+      |> assert_has_patch("lib/test/accounts/user.ex", """
+      + |    otp :otp do
+      + |      identity_field(:email)
+      + |      brute_force_strategy({:audit_log, :audit_log})
+      + |      sender(Test.Accounts.User.Senders.SendOtp)
+      + |    end
+      """)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `mix ash_authentication.add_strategy.otp`, completing parity with the other strategies after the OTP strategy was introduced in #1141.
- Wires `otp` into `mix ash_authentication.add_strategy` so it's reachable via the parent task and via `mix igniter.install ash_authentication --auth-strategy otp`.

## Behaviour

The task generates:

- the identity attribute (defaults to `:email`, type `:ci_string`),
- a unique identity for that field,
- a `get_by_<field>` lookup action,
- explicit `request_<name>` and `sign_in_with_<name>` actions (matching magic_link's pattern, so users can edit them after generation),
- a stub `SendOtp` sender that prints to stdout (the Phoenix counterpart upgrades this to Swoosh).

Brute-force protection defaults to ``brute_force_strategy {:audit_log, :audit_log}``, composing the audit_log add-on if not already present — same approach TOTP and recovery_code take.

`--registration` is rejected with a pointer to the OTP tutorial, because the verifier forbids ``{:audit_log, ...}`` in registration mode and the alternatives (``:rate_limit`` with AshRateLimiter, or ``{:preparation, mod}``) need user decisions this generator can't safely make.

## Test plan

- [x] 16 new tests in ``test/mix/tasks/ash_authentication.add_strategy.otp_test.exs`` covering default invocation, audit_log composition, custom strategy/identity-field names, missing user, idempotency, and combination with password.
- [x] Wider mix-task suite (87 tests) still green.
- [x] End-to-end smoke-tested in a fresh phoenix project: ``mix igniter.new`` → ``mix ash_authentication.install`` → ``mix ash_authentication.add_strategy otp`` produces a working user resource that compiles cleanly.