### PR TITLE
fix: gracefully degrade row locks on data layers without lock support

### DIFF
--- a/lib/ash_authentication/add_ons/audit_log/brute_force_helpers.ex
+++ b/lib/ash_authentication/add_ons/audit_log/brute_force_helpers.ex
@@ -14,6 +14,7 @@ defmodule AshAuthentication.AddOn.AuditLog.BruteForceHelpers do
 
   require Ash.Query
   import Ash.Expr
+  import AshAuthentication.Utils, only: [maybe_lock: 2]
 
   alias AshAuthentication.AuditLogResource
 
@@ -62,7 +63,7 @@ defmodule AshAuthentication.AddOn.AuditLog.BruteForceHelpers do
     |> apply_criteria(audit_log_resource, criteria)
     |> Ash.Query.filter(^ref(status_attr) == :failure)
     |> Ash.Query.filter(^ref(logged_at_attr) >= ^cutoff)
-    |> Ash.Query.lock("FOR UPDATE")
+    |> maybe_lock("FOR UPDATE")
     |> Ash.count()
   end
 

--- a/lib/ash_authentication/audit_log_resource.ex
+++ b/lib/ash_authentication/audit_log_resource.ex
@@ -203,7 +203,8 @@ defmodule AshAuthentication.AuditLogResource do
 
   use Spark.Dsl.Extension,
     sections: @dsl,
-    transformers: [AuditLogResource.Transformer]
+    transformers: [AuditLogResource.Transformer],
+    verifiers: [AuditLogResource.Verifier]
 
   @doc """
   Log an authentication event into the audit logger.

--- a/lib/ash_authentication/audit_log_resource/verifier.ex
+++ b/lib/ash_authentication/audit_log_resource/verifier.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.AuditLogResource.Verifier do
+  @moduledoc """
+  Compile-time checks for the audit log resource.
+  """
+
+  use Spark.Dsl.Verifier
+  alias Spark.Dsl.Verifier
+  import AshAuthentication.Validations, only: [warn_if_data_layer_cannot_lock: 2]
+
+  @doc false
+  @impl true
+  @spec verify(map) :: :ok | {:error, term}
+  def verify(dsl_state) do
+    warn_if_data_layer_cannot_lock(
+      Verifier.get_persisted(dsl_state, :module),
+      "Brute-force protection counts failed attempts inside a `SELECT ... FOR UPDATE` window so concurrent attempts can't slip past the threshold."
+    )
+  end
+end

--- a/lib/ash_authentication/strategies/otp/sign_in_helpers.ex
+++ b/lib/ash_authentication/strategies/otp/sign_in_helpers.ex
@@ -7,6 +7,7 @@ defmodule AshAuthentication.Strategy.Otp.SignInHelpers do
 
   alias AshAuthentication.TokenResource
   alias AshAuthentication.TokenResource.Info, as: TokenInfo
+  import AshAuthentication.Utils, only: [maybe_lock: 2]
 
   @doc """
   Fetch a stored OTP token by JTI while holding a `SELECT FOR UPDATE` row lock.
@@ -23,7 +24,7 @@ defmodule AshAuthentication.Strategy.Otp.SignInHelpers do
       token_resource
       |> Ash.Query.new()
       |> Ash.Query.set_context(%{private: %{ash_authentication?: true}})
-      |> Ash.Query.lock(:for_update)
+      |> maybe_lock(:for_update)
       |> Ash.Query.for_read(
         get_token_action_name,
         %{"jti" => jti, "purpose" => "otp"},

--- a/lib/ash_authentication/strategies/recovery_code/verifier.ex
+++ b/lib/ash_authentication/strategies/recovery_code/verifier.ex
@@ -12,13 +12,19 @@ defmodule AshAuthentication.Strategy.RecoveryCode.Verifier do
   alias Spark.Dsl.Verifier
   alias Spark.Error.DslError
 
+  import AshAuthentication.Validations, only: [warn_if_data_layer_cannot_lock: 2]
+
   @doc false
   @spec verify(RecoveryCode.t(), map) :: :ok | {:error, Exception.t()}
   def verify(strategy, dsl) do
     with :ok <- validate_brute_force_strategy(dsl, strategy),
          :ok <- validate_entropy(dsl, strategy),
-         :ok <- validate_code_alphabet(dsl, strategy) do
-      validate_recovery_code_resource(dsl, strategy)
+         :ok <- validate_code_alphabet(dsl, strategy),
+         :ok <- validate_recovery_code_resource(dsl, strategy) do
+      warn_if_data_layer_cannot_lock(
+        strategy.recovery_code_resource,
+        "Recovery-code verification reads stored codes inside a `SELECT FOR UPDATE` window when using a non-deterministic hash provider, so concurrent verifications can't both consume the same code."
+      )
     end
   end
 

--- a/lib/ash_authentication/strategies/recovery_code/verify_action.ex
+++ b/lib/ash_authentication/strategies/recovery_code/verify_action.ex
@@ -19,6 +19,7 @@ defmodule AshAuthentication.Strategy.RecoveryCode.VerifyAction do
   use Ash.Resource.Actions.Implementation
   require Ash.Query
   import Ash.Expr, only: [ref: 1]
+  import AshAuthentication.Utils, only: [maybe_lock: 2]
   alias Ash.ActionInput
   alias AshAuthentication.Info
 
@@ -90,7 +91,7 @@ defmodule AshAuthentication.Strategy.RecoveryCode.VerifyAction do
       strategy.recovery_code_resource
       |> Ash.Query.filter(^ref(user_id_field) == ^user.id)
       |> Ash.Query.set_context(%{private: %{ash_authentication?: true}})
-      |> Ash.Query.lock(:for_update)
+      |> maybe_lock(:for_update)
       |> Ash.read!(Keyword.merge(opts, domain: domain))
 
     matched = find_matching_code(codes, code, code_field, strategy)

--- a/lib/ash_authentication/token_resource/actions.ex
+++ b/lib/ash_authentication/token_resource/actions.ex
@@ -232,11 +232,11 @@ defmodule AshAuthentication.TokenResource.Actions do
            opts
            |> Keyword.take([:actor, :authorize?, :context, :tenant, :tracer])
            |> Keyword.merge(
-             lock: :for_update,
              domain: domain,
              authorize?: false,
              error?: false
-           ),
+           )
+           |> maybe_lock_opt(resource, :for_update),
          {:ok, existing} <- Ash.get(resource, [jti: jti], lookup_opts) do
       case existing && existing.purpose do
         "revocation" ->
@@ -319,11 +319,11 @@ defmodule AshAuthentication.TokenResource.Actions do
            opts
            |> Keyword.take([:actor, :authorize?, :context, :tenant, :tracer])
            |> Keyword.merge(
-             lock: :for_update,
              domain: domain,
              authorize?: false,
              error?: false
-           ),
+           )
+           |> maybe_lock_opt(resource, :for_update),
          {:ok, existing} <- Ash.get(resource, [jti: jti], lookup_opts) do
       case existing && existing.purpose do
         "revocation" ->

--- a/lib/ash_authentication/token_resource/verifier.ex
+++ b/lib/ash_authentication/token_resource/verifier.ex
@@ -11,14 +11,19 @@ defmodule AshAuthentication.TokenResource.Verifier do
   require Logger
   alias Spark.{Dsl.Verifier, Error.DslError}
   import AshAuthentication.Utils
+  import AshAuthentication.Validations, only: [warn_if_data_layer_cannot_lock: 2]
   import AshAuthentication.Validations.Action
 
   @doc false
   @impl true
   @spec verify(map) :: :ok | {:error, term}
   def verify(dsl_state) do
-    with :ok <- validate_domain_presence(dsl_state) do
-      maybe_validate_is_revoked_action_arguments(dsl_state)
+    with :ok <- validate_domain_presence(dsl_state),
+         :ok <- maybe_validate_is_revoked_action_arguments(dsl_state) do
+      warn_if_data_layer_cannot_lock(
+        Verifier.get_persisted(dsl_state, :module),
+        "Token revocation relies on a `SELECT FOR UPDATE` row lock to make concurrent revocation race-free."
+      )
     end
   end
 

--- a/lib/ash_authentication/utils.ex
+++ b/lib/ash_authentication/utils.ex
@@ -304,4 +304,40 @@ defmodule AshAuthentication.Utils do
     do: Map.new(map, fn {k, v} -> {k, normalize_null(v)} end)
 
   def normalize_null(value), do: value
+
+  @doc """
+  Apply `Ash.Query.lock/2` only when the resource's data layer supports the
+  given lock type. On data layers that don't support locking (e.g. ETS),
+  returns the query unchanged.
+
+  This is intentionally a soft fallback: data layers without locking are
+  typically single-process and serialise writes by other means, so the
+  atomicity that the lock provides on SQL-backed data layers is already
+  guaranteed there. Resources that genuinely need lock-based safety should
+  surface a compile-time warning via the relevant verifier.
+  """
+  @spec maybe_lock(Ash.Query.t(), Ash.DataLayer.lock_type()) :: Ash.Query.t()
+  def maybe_lock(query, lock_type) do
+    if Ash.DataLayer.data_layer_can?(query.resource, {:lock, lock_type}) do
+      Ash.Query.lock(query, lock_type)
+    else
+      query
+    end
+  end
+
+  @doc """
+  Add a `:lock` keyword option to `opts` only when the resource's data
+  layer supports the given lock type.
+
+  Counterpart to `maybe_lock/2` for code paths that pass options directly
+  to `Ash.get/3` and friends rather than building a query.
+  """
+  @spec maybe_lock_opt(keyword, Ash.Resource.t(), Ash.DataLayer.lock_type()) :: keyword
+  def maybe_lock_opt(opts, resource, lock_type) do
+    if Ash.DataLayer.data_layer_can?(resource, {:lock, lock_type}) do
+      Keyword.put(opts, :lock, lock_type)
+    else
+      opts
+    end
+  end
 end

--- a/lib/ash_authentication/validations.ex
+++ b/lib/ash_authentication/validations.ex
@@ -206,4 +206,39 @@ defmodule AshAuthentication.Validations do
          )}
     end
   end
+
+  @doc """
+  Emit a `Logger.warning` if the given resource's data layer does not support
+  the `{:lock, :for_update}` capability.
+
+  Used by verifiers for resources that AshAuthentication tries to lock at
+  runtime (the token resource, the audit log resource, the recovery code
+  resource). On data layers that don't support locking the lock is skipped
+  at runtime — but races between concurrent processes are no longer
+  prevented, which the user should know about.
+
+  Returns `:ok` either way; this is advisory, not a hard failure.
+  """
+  @spec warn_if_data_layer_cannot_lock(Ash.Resource.t(), String.t()) :: :ok
+  def warn_if_data_layer_cannot_lock(resource, context) do
+    if Ash.DataLayer.data_layer_can?(resource, {:lock, :for_update}) do
+      :ok
+    else
+      require Logger
+
+      Logger.warning("""
+      The data layer for #{inspect(resource)} does not support row locking.
+
+      #{context}
+
+      AshAuthentication will skip the lock at runtime so the operation does
+      not crash, but races between concurrent processes are no longer
+      serialised by the database. If you need lock-based safety, switch to a
+      data layer that supports `{:lock, :for_update}` (for example
+      `AshPostgres.DataLayer`).
+      """)
+
+      :ok
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Five places in AshAuthentication issue ``Ash.Query.lock(:for_update)`` (or its keyword equivalent on ``Ash.get/3``):

- OTP sign-in's deterministic-JTI lookup
- Recovery code verification with non-deterministic hash providers
- Audit log brute-force counting
- Token revocation by token (``revoke/3``)
- Token revocation by JTI (``revoke_jti/4``)

Until now those calls were unconditional. On data layers that don't support row locking — notably ``Ash.DataLayer.Ets`` — ``Ash.Query.lock/2`` attaches an ``Ash.Error.Query.LockNotSupported`` to the query, surfacing as a hard error at runtime.

This breaks downstream projects that use ETS for tokens. In particular, every TOTP confirm-setup attempt in [ash_authentication_phoenix's test suite](https://github.com/team-alembic/ash_authentication_phoenix) crashed after #1153 (atomic token revocation) shipped, because that suite uses an ETS-backed Token fixture.

## Approach

Wrap the lock at each call site in two tiny helpers added to ``AshAuthentication.Utils``:

- ``maybe_lock(query, lock_type)`` — applies ``Ash.Query.lock/2`` only when the resource's data layer can honour it.
- ``maybe_lock_opt(opts, resource, lock_type)`` — adds the ``:lock`` keyword to ``opts`` only when supported.

Both check ``Ash.DataLayer.data_layer_can?(resource, {:lock, lock_type})`` first.

This is a soft fallback rather than a silent footgun: single-process data layers like ETS already serialise writes through the data-layer process, so the atomicity that the lock provides on SQL-backed data layers is implicitly preserved there. The lock is only meaningful when the data layer can have multiple concurrent writers — which is exactly when the capability check returns true.

## Compile-time warnings

To make sure users picking a non-locking data layer in production know what they've lost, three verifiers now emit a ``Logger.warning`` at compile time when the relevant resource's data layer can't lock:

- ``TokenResource.Verifier`` — fires for the token resource itself.
- ``RecoveryCode.Verifier`` — fires for the recovery code resource.
- A new ``AuditLogResource.Verifier`` (the audit log resource previously had only a transformer) — fires for the audit log resource.

The warnings are advisory, not hard errors. The underlying helper lives in ``AshAuthentication.Validations.warn_if_data_layer_cannot_lock/2``.

## Test plan

- [x] All 614 AA tests still green.
- [x] Verified end-to-end against ash_authentication_phoenix's test suite by pointing its ``mix.exs`` at this branch — the previously-failing 13 TOTP tests now pass and the full 135-test suite is green.
- [x] Compile of AA emits the expected warning for ``Example.TokenWithCustomCreateTimestamp`` (a fixture without a postgres data layer), confirming the verifier wiring works.