### PR TITLE
fix: respect optional wax_ dependency for WebAuthn

### DIFF
--- a/lib/ash_authentication/strategies/webauthn/actions.ex
+++ b/lib/ash_authentication/strategies/webauthn/actions.ex
@@ -10,428 +10,469 @@ defmodule AshAuthentication.Strategy.WebAuthn.Actions do
   with Ash to persist users and credentials.
   """
 
-  alias Ash.{Changeset, Query}
-  alias AshAuthentication.{Errors.AuthenticationFailed, Info, Jwt, Strategy.WebAuthn}
-  require Ash.Query
-  require Logger
+  alias AshAuthentication.Errors.AuthenticationFailed
 
-  @doc "Generate a registration challenge."
-  @spec registration_challenge(WebAuthn.t(), any) :: {:ok, Wax.Challenge.t()}
-  def registration_challenge(strategy, tenant) do
-    opts = WebAuthn.Helpers.wax_opts(strategy, tenant)
-    challenge = Wax.new_registration_challenge(opts)
-    {:ok, challenge}
-  end
+  if Code.ensure_loaded?(Wax) do
+    alias Ash.{Changeset, Query}
+    alias AshAuthentication.{Info, Jwt, Strategy.WebAuthn}
+    require Ash.Query
+    require Logger
 
-  @doc "Generate an authentication challenge."
-  @spec authentication_challenge(WebAuthn.t(), list, any) :: {:ok, Wax.Challenge.t()}
-  def authentication_challenge(strategy, allow_credentials, tenant) do
-    opts =
-      strategy
-      |> WebAuthn.Helpers.wax_opts(tenant)
-      |> Keyword.put(:allow_credentials, allow_credentials)
+    @doc "Generate a registration challenge."
+    @spec registration_challenge(WebAuthn.t(), any) :: {:ok, Wax.Challenge.t()}
+    def registration_challenge(strategy, tenant) do
+      opts = WebAuthn.Helpers.wax_opts(strategy, tenant)
+      challenge = Wax.new_registration_challenge(opts)
+      {:ok, challenge}
+    end
 
-    challenge = Wax.new_authentication_challenge(opts)
-    {:ok, challenge}
-  end
+    @doc "Generate an authentication challenge."
+    @spec authentication_challenge(WebAuthn.t(), list, any) :: {:ok, Wax.Challenge.t()}
+    def authentication_challenge(strategy, allow_credentials, tenant) do
+      opts =
+        strategy
+        |> WebAuthn.Helpers.wax_opts(tenant)
+        |> Keyword.put(:allow_credentials, allow_credentials)
 
-  @doc "Register a new user with a WebAuthn credential."
-  @spec register(WebAuthn.t(), map, keyword) :: {:ok, Ash.Resource.record()} | {:error, any}
-  def register(strategy, params, opts \\ []) do
-    challenge = Keyword.fetch!(opts, :challenge)
+      challenge = Wax.new_authentication_challenge(opts)
+      {:ok, challenge}
+    end
 
-    with {:ok, attestation_object} <- safe_url_decode64(params["attestation_object"]),
-         {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
-         {:ok, {auth_data, _}} <-
-           wax_register(strategy, attestation_object, client_data_json, challenge),
-         {:ok, user} <- create_user_from_registration(strategy, auth_data, params, opts) do
-      case store_credential_from_auth(strategy, user, auth_data, params, opts) do
-        {:ok, _credential} ->
-          {:ok, user}
+    @doc "Register a new user with a WebAuthn credential."
+    @spec register(WebAuthn.t(), map, keyword) :: {:ok, Ash.Resource.record()} | {:error, any}
+    def register(strategy, params, opts \\ []) do
+      challenge = Keyword.fetch!(opts, :challenge)
 
-        {:error, error} ->
-          cleanup_orphaned_user(user, opts)
-          {:error, error}
+      with {:ok, attestation_object} <- safe_url_decode64(params["attestation_object"]),
+           {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
+           {:ok, {auth_data, _}} <-
+             wax_register(strategy, attestation_object, client_data_json, challenge),
+           {:ok, user} <- create_user_from_registration(strategy, auth_data, params, opts) do
+        case store_credential_from_auth(strategy, user, auth_data, params, opts) do
+          {:ok, _credential} ->
+            {:ok, user}
+
+          {:error, error} ->
+            cleanup_orphaned_user(user, opts)
+            {:error, error}
+        end
+      else
+        :error -> base64_error(strategy, :register)
+        {:error, error} -> {:error, error}
       end
-    else
-      :error -> base64_error(strategy, :register)
-      {:error, error} -> {:error, error}
     end
-  end
 
-  # Compensating cleanup: if credential store fails after user creation, destroy
-  # the user to prevent orphans. Failure to clean up is logged loudly but does
-  # not mask the original error.
-  defp cleanup_orphaned_user(user, opts) do
-    ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
+    # Compensating cleanup: if credential store fails after user creation, destroy
+    # the user to prevent orphans. Failure to clean up is logged loudly but does
+    # not mask the original error.
+    defp cleanup_orphaned_user(user, opts) do
+      ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
 
-    user
-    |> Changeset.new()
-    |> Changeset.set_context(auth_context())
-    |> Ash.destroy(ash_opts)
-    |> case do
-      :ok ->
-        :ok
-
-      {:ok, _} ->
-        :ok
-
-      {:error, error} ->
-        Logger.error(
-          "Failed to clean up orphaned user after WebAuthn credential store failure: " <>
-            inspect(error)
-        )
-
-        :error
-    end
-  end
-
-  @doc "Sign in a user with a WebAuthn credential."
-  @spec sign_in(WebAuthn.t(), map, keyword) :: {:ok, Ash.Resource.record()} | {:error, any}
-  def sign_in(strategy, params, opts \\ []) do
-    challenge = Keyword.fetch!(opts, :challenge)
-    tenant = Keyword.get(opts, :tenant)
-
-    with {:ok, raw_id} <- safe_url_decode64(params["raw_id"]),
-         {:ok, authenticator_data} <- safe_url_decode64(params["authenticator_data"]),
-         {:ok, signature} <- safe_url_decode64(params["signature"]),
-         {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
-         {:ok, auth_data} <-
-           wax_authenticate(
-             strategy,
-             raw_id,
-             authenticator_data,
-             signature,
-             client_data_json,
-             challenge
-           ),
-         {:ok, user} <- find_user_for_sign_in(strategy, params, opts),
-         :ok <- best_effort_update_sign_count(strategy, raw_id, auth_data.sign_count, tenant) do
-      maybe_generate_token(user, strategy, opts)
-    else
-      :error -> base64_error(strategy, :sign_in)
-      {:error, error} -> {:error, error}
-    end
-  end
-
-  @doc "List all credentials for a user."
-  @spec list_credentials(WebAuthn.t(), Ash.Resource.record(), keyword) ::
-          {:ok, [Ash.Resource.record()]} | {:error, any}
-  def list_credentials(strategy, user, opts) do
-    ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
-
-    strategy.credential_resource
-    |> Query.new()
-    |> Query.set_context(auth_context())
-    |> Query.for_read(:read, %{}, ash_opts)
-    |> Query.filter(user_id == ^user.id)
-    |> Query.sort(inserted_at: :asc)
-    |> Ash.read()
-  end
-
-  @doc "Delete a credential, refusing to delete the last one."
-  @spec delete_credential(WebAuthn.t(), Ash.Resource.record(), any, keyword) ::
-          :ok | {:error, any}
-  def delete_credential(strategy, user, credential_id, opts) do
-    with {:ok, credentials} <- list_credentials(strategy, user, opts),
-         :ok <- ensure_not_last_credential(strategy, credentials),
-         {:ok, credential} <- find_credential(strategy, credentials, credential_id) do
-      destroy_credential(credential, opts)
-    end
-  end
-
-  @doc "Update the label of a credential."
-  @spec update_credential_label(WebAuthn.t(), any, String.t(), keyword) ::
-          {:ok, Ash.Resource.record()} | {:error, any}
-  def update_credential_label(strategy, credential_id, new_label, opts) do
-    ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
-
-    with {:ok, credential} <- Ash.get(strategy.credential_resource, credential_id, ash_opts) do
-      credential
+      user
       |> Changeset.new()
       |> Changeset.set_context(auth_context())
-      |> Changeset.for_update(:update, %{label: new_label}, ash_opts)
-      |> Ash.update()
+      |> Ash.destroy(ash_opts)
+      |> case do
+        :ok ->
+          :ok
+
+        {:ok, _} ->
+          :ok
+
+        {:error, error} ->
+          Logger.error(
+            "Failed to clean up orphaned user after WebAuthn credential store failure: " <>
+              inspect(error)
+          )
+
+          :error
+      end
     end
-  end
 
-  @doc """
-  Add a new WebAuthn credential to an existing user.
+    @doc "Sign in a user with a WebAuthn credential."
+    @spec sign_in(WebAuthn.t(), map, keyword) :: {:ok, Ash.Resource.record()} | {:error, any}
+    def sign_in(strategy, params, opts \\ []) do
+      challenge = Keyword.fetch!(opts, :challenge)
+      tenant = Keyword.get(opts, :tenant)
 
-  This is used when a user wants to register an additional security key or passkey.
-  Unlike `register/3`, this does NOT create a new user - it attaches a credential
-  to an existing one.
-
-  Params should include:
-  - `"attestation_object"` - Base64url-encoded attestation object from the browser
-  - `"client_data_json"` - Base64url-encoded client data JSON from the browser
-  - `"label"` - Optional human-readable label for the credential
-
-  Options must include:
-  - `challenge:` - The Wax.Challenge used for this ceremony
-  - `user:` - The existing user to attach the credential to
-  """
-  @spec add_credential(WebAuthn.t(), map, keyword) ::
-          {:ok, Ash.Resource.record()} | {:error, any}
-  def add_credential(strategy, params, opts \\ []) do
-    challenge = Keyword.fetch!(opts, :challenge)
-    user = Keyword.fetch!(opts, :user)
-    tenant = Keyword.get(opts, :tenant)
-
-    with {:ok, attestation_object} <- safe_url_decode64(params["attestation_object"]),
-         {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
-         {:ok, {auth_data, _}} <-
-           wax_register_credential(strategy, attestation_object, client_data_json, challenge) do
-      store_credential(
-        strategy,
-        user,
-        auth_data.attested_credential_data,
-        auth_data.sign_count,
-        params["label"],
-        tenant
-      )
-    else
-      :error -> base64_error(strategy, :add_credential)
-      {:error, error} -> {:error, error}
+      with {:ok, raw_id} <- safe_url_decode64(params["raw_id"]),
+           {:ok, authenticator_data} <- safe_url_decode64(params["authenticator_data"]),
+           {:ok, signature} <- safe_url_decode64(params["signature"]),
+           {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
+           {:ok, auth_data} <-
+             wax_authenticate(
+               strategy,
+               raw_id,
+               authenticator_data,
+               signature,
+               client_data_json,
+               challenge
+             ),
+           {:ok, user} <- find_user_for_sign_in(strategy, params, opts),
+           :ok <- best_effort_update_sign_count(strategy, raw_id, auth_data.sign_count, tenant) do
+        maybe_generate_token(user, strategy, opts)
+      else
+        :error -> base64_error(strategy, :sign_in)
+        {:error, error} -> {:error, error}
+      end
     end
-  end
 
-  defp wax_register_credential(strategy, attestation_object, client_data_json, challenge) do
-    case Wax.register(attestation_object, client_data_json, challenge) do
-      {:ok, _} = success ->
-        success
+    @doc "List all credentials for a user."
+    @spec list_credentials(WebAuthn.t(), Ash.Resource.record(), keyword) ::
+            {:ok, [Ash.Resource.record()]} | {:error, any}
+    def list_credentials(strategy, user, opts) do
+      ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
 
-      {:error, error} ->
-        {:error, auth_failed(strategy, :add_credential, inspect(error))}
+      strategy.credential_resource
+      |> Query.new()
+      |> Query.set_context(auth_context())
+      |> Query.for_read(:read, %{}, ash_opts)
+      |> Query.filter(user_id == ^user.id)
+      |> Query.sort(inserted_at: :asc)
+      |> Ash.read()
     end
-  end
 
-  defp wax_register(strategy, attestation_object, client_data_json, challenge) do
-    case Wax.register(attestation_object, client_data_json, challenge) do
-      {:ok, _} = success ->
-        success
-
-      {:error, error} ->
-        {:error, auth_failed(strategy, :register, inspect(error))}
+    @doc "Delete a credential, refusing to delete the last one."
+    @spec delete_credential(WebAuthn.t(), Ash.Resource.record(), any, keyword) ::
+            :ok | {:error, any}
+    def delete_credential(strategy, user, credential_id, opts) do
+      with {:ok, credentials} <- list_credentials(strategy, user, opts),
+           :ok <- ensure_not_last_credential(strategy, credentials),
+           {:ok, credential} <- find_credential(strategy, credentials, credential_id) do
+        destroy_credential(credential, opts)
+      end
     end
-  end
 
-  defp wax_authenticate(
-         strategy,
-         raw_id,
-         authenticator_data,
-         signature,
-         client_data_json,
-         challenge
-       ) do
-    case Wax.authenticate(raw_id, authenticator_data, signature, client_data_json, challenge) do
-      {:ok, _} = success ->
-        success
+    @doc "Update the label of a credential."
+    @spec update_credential_label(WebAuthn.t(), any, String.t(), keyword) ::
+            {:ok, Ash.Resource.record()} | {:error, any}
+    def update_credential_label(strategy, credential_id, new_label, opts) do
+      ash_opts = internal_ash_opts(Keyword.get(opts, :tenant))
 
-      {:error, error} ->
-        {:error, auth_failed(strategy, :sign_in, inspect(error))}
-    end
-  end
-
-  defp create_user_from_registration(strategy, auth_data, params, opts) do
-    tenant = Keyword.get(opts, :tenant)
-    cred_data = auth_data.attested_credential_data
-    identity_key = to_string(strategy.identity_field)
-
-    action_params = %{
-      identity_key => params[identity_key],
-      "credential_id" => cred_data.credential_id,
-      "public_key" => cred_data.credential_public_key,
-      "sign_count" => auth_data.sign_count,
-      "label" => params["label"] || "Security Key"
-    }
-
-    ash_opts = build_ash_opts(strategy, opts, tenant)
-
-    strategy.resource
-    |> Changeset.new()
-    |> Changeset.set_context(auth_context())
-    |> Changeset.for_create(strategy.register_action_name, action_params, ash_opts)
-    |> Ash.create()
-  end
-
-  defp store_credential_from_auth(strategy, user, auth_data, params, opts) do
-    tenant = Keyword.get(opts, :tenant)
-    cred_data = auth_data.attested_credential_data
-    store_credential(strategy, user, cred_data, auth_data.sign_count, params["label"], tenant)
-  end
-
-  defp find_user_for_sign_in(strategy, params, opts) do
-    tenant = Keyword.get(opts, :tenant)
-    identity_value = params[to_string(strategy.identity_field)]
-    ash_opts = build_ash_opts(strategy, opts, tenant)
-
-    strategy.resource
-    |> Query.new()
-    |> Query.set_context(auth_context())
-    |> Query.for_read(
-      strategy.sign_in_action_name,
-      %{strategy.identity_field => identity_value},
-      ash_opts
-    )
-    |> Ash.read()
-    |> handle_user_query_result(strategy)
-  end
-
-  defp handle_user_query_result({:ok, [user]}, _strategy), do: {:ok, user}
-
-  defp handle_user_query_result({:ok, []}, strategy),
-    do: {:error, auth_failed(strategy, :sign_in, "Query returned no users")}
-
-  defp handle_user_query_result({:ok, _}, strategy),
-    do: {:error, auth_failed(strategy, :sign_in, "Query returned too many users")}
-
-  defp handle_user_query_result({:error, %AuthenticationFailed{} = error}, _strategy),
-    do: {:error, error}
-
-  defp handle_user_query_result({:error, error}, strategy) when is_exception(error),
-    do: {:error, AuthenticationFailed.exception(strategy: strategy, caused_by: error)}
-
-  defp handle_user_query_result({:error, _}, strategy),
-    do: {:error, auth_failed(strategy, :sign_in, "Authentication failed")}
-
-  defp best_effort_update_sign_count(strategy, credential_id, new_count, tenant) do
-    update_sign_count(strategy, credential_id, new_count, tenant)
-    :ok
-  end
-
-  defp ensure_not_last_credential(strategy, credentials) do
-    if length(credentials) <= 1 do
-      {:error, auth_failed(strategy, :delete_credential, "Cannot delete the last credential")}
-    else
-      :ok
-    end
-  end
-
-  defp find_credential(strategy, credentials, credential_id) do
-    case Enum.find(credentials, &(&1.id == credential_id)) do
-      nil -> {:error, auth_failed(strategy, :delete_credential, "Credential not found")}
-      credential -> {:ok, credential}
-    end
-  end
-
-  defp destroy_credential(credential, opts) do
-    tenant = Keyword.get(opts, :tenant)
-    ash_opts = [authorize?: false]
-    ash_opts = if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
-
-    credential
-    |> Changeset.new()
-    |> Changeset.set_context(auth_context())
-    |> Ash.destroy(ash_opts)
-  end
-
-  defp build_ash_opts(strategy, opts, tenant) do
-    ash_opts =
-      opts
-      |> Keyword.take([:actor])
-      |> Keyword.put_new_lazy(:domain, fn -> Info.domain!(strategy.resource) end)
-
-    if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
-  end
-
-  defp auth_context, do: %{private: %{ash_authentication?: true}}
-
-  defp auth_failed(strategy, action, message) do
-    AuthenticationFailed.exception(
-      strategy: strategy,
-      caused_by: %{
-        module: __MODULE__,
-        strategy: strategy,
-        action: action,
-        message: message
-      }
-    )
-  end
-
-  defp base64_error(strategy, action) do
-    {:error, auth_failed(strategy, action, "Invalid base64 encoding in request parameters")}
-  end
-
-  defp store_credential(strategy, user, cred_data, sign_count, label, tenant) do
-    attrs = %{
-      credential_id: cred_data.credential_id,
-      public_key: cred_data.credential_public_key,
-      sign_count: sign_count,
-      label: label || "Security Key",
-      user_id: user.id
-    }
-
-    ash_opts = internal_ash_opts(tenant)
-
-    strategy.credential_resource
-    |> Changeset.new()
-    |> Changeset.set_context(auth_context())
-    |> Changeset.for_create(:create, attrs, ash_opts)
-    |> Ash.create()
-  end
-
-  defp update_sign_count(strategy, credential_id, new_count, tenant) do
-    ash_opts = internal_ash_opts(tenant)
-
-    strategy.credential_resource
-    |> Query.new()
-    |> Query.set_context(auth_context())
-    |> Query.for_read(:read, %{}, ash_opts)
-    |> Query.filter(credential_id == ^credential_id)
-    |> Ash.read_one()
-    |> case do
-      {:ok, nil} ->
-        :ok
-
-      {:ok, credential} ->
+      with {:ok, credential} <- Ash.get(strategy.credential_resource, credential_id, ash_opts) do
         credential
         |> Changeset.new()
         |> Changeset.set_context(auth_context())
-        |> Changeset.for_update(
-          :update,
-          %{sign_count: new_count, last_used_at: DateTime.utc_now()},
-          ash_opts
-        )
+        |> Changeset.for_update(:update, %{label: new_label}, ash_opts)
         |> Ash.update()
-        |> case do
-          {:ok, _} -> :ok
-          {:error, error} -> log_sign_count_failure(error)
-        end
-
-      {:error, error} ->
-        log_sign_count_failure(error)
+      end
     end
-  end
 
-  defp log_sign_count_failure(error) do
-    Logger.warning("Failed to update WebAuthn sign count: #{inspect(error)}")
-    :ok
-  end
+    @doc """
+    Add a new WebAuthn credential to an existing user.
 
-  defp internal_ash_opts(tenant) do
-    ash_opts = [authorize?: false]
-    if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
-  end
+    This is used when a user wants to register an additional security key or passkey.
+    Unlike `register/3`, this does NOT create a new user - it attaches a credential
+    to an existing one.
 
-  defp maybe_generate_token(user, strategy, opts) do
-    if Info.authentication_tokens_enabled?(strategy.resource) do
-      case Jwt.token_for_user(user, %{"purpose" => "user"}, Keyword.take(opts, [:tenant])) do
-        {:ok, token, _claims} ->
-          {:ok, Ash.Resource.put_metadata(user, :token, token)}
+    Params should include:
+    - `"attestation_object"` - Base64url-encoded attestation object from the browser
+    - `"client_data_json"` - Base64url-encoded client data JSON from the browser
+    - `"label"` - Optional human-readable label for the credential
+
+    Options must include:
+    - `challenge:` - The Wax.Challenge used for this ceremony
+    - `user:` - The existing user to attach the credential to
+    """
+    @spec add_credential(WebAuthn.t(), map, keyword) ::
+            {:ok, Ash.Resource.record()} | {:error, any}
+    def add_credential(strategy, params, opts \\ []) do
+      challenge = Keyword.fetch!(opts, :challenge)
+      user = Keyword.fetch!(opts, :user)
+      tenant = Keyword.get(opts, :tenant)
+
+      with {:ok, attestation_object} <- safe_url_decode64(params["attestation_object"]),
+           {:ok, client_data_json} <- safe_url_decode64(params["client_data_json"]),
+           {:ok, {auth_data, _}} <-
+             wax_register_credential(strategy, attestation_object, client_data_json, challenge) do
+        store_credential(
+          strategy,
+          user,
+          auth_data.attested_credential_data,
+          auth_data.sign_count,
+          params["label"],
+          tenant
+        )
+      else
+        :error -> base64_error(strategy, :add_credential)
+        {:error, error} -> {:error, error}
+      end
+    end
+
+    defp wax_register_credential(strategy, attestation_object, client_data_json, challenge) do
+      case Wax.register(attestation_object, client_data_json, challenge) do
+        {:ok, _} = success ->
+          success
 
         {:error, error} ->
-          {:error, error}
+          {:error, auth_failed(strategy, :add_credential, inspect(error))}
       end
-    else
-      {:ok, user}
+    end
+
+    defp wax_register(strategy, attestation_object, client_data_json, challenge) do
+      case Wax.register(attestation_object, client_data_json, challenge) do
+        {:ok, _} = success ->
+          success
+
+        {:error, error} ->
+          {:error, auth_failed(strategy, :register, inspect(error))}
+      end
+    end
+
+    defp wax_authenticate(
+           strategy,
+           raw_id,
+           authenticator_data,
+           signature,
+           client_data_json,
+           challenge
+         ) do
+      case Wax.authenticate(raw_id, authenticator_data, signature, client_data_json, challenge) do
+        {:ok, _} = success ->
+          success
+
+        {:error, error} ->
+          {:error, auth_failed(strategy, :sign_in, inspect(error))}
+      end
+    end
+
+    defp create_user_from_registration(strategy, auth_data, params, opts) do
+      tenant = Keyword.get(opts, :tenant)
+      cred_data = auth_data.attested_credential_data
+      identity_key = to_string(strategy.identity_field)
+
+      action_params = %{
+        identity_key => params[identity_key],
+        "credential_id" => cred_data.credential_id,
+        "public_key" => cred_data.credential_public_key,
+        "sign_count" => auth_data.sign_count,
+        "label" => params["label"] || "Security Key"
+      }
+
+      ash_opts = build_ash_opts(strategy, opts, tenant)
+
+      strategy.resource
+      |> Changeset.new()
+      |> Changeset.set_context(auth_context())
+      |> Changeset.for_create(strategy.register_action_name, action_params, ash_opts)
+      |> Ash.create()
+    end
+
+    defp store_credential_from_auth(strategy, user, auth_data, params, opts) do
+      tenant = Keyword.get(opts, :tenant)
+      cred_data = auth_data.attested_credential_data
+      store_credential(strategy, user, cred_data, auth_data.sign_count, params["label"], tenant)
+    end
+
+    defp find_user_for_sign_in(strategy, params, opts) do
+      tenant = Keyword.get(opts, :tenant)
+      identity_value = params[to_string(strategy.identity_field)]
+      ash_opts = build_ash_opts(strategy, opts, tenant)
+
+      strategy.resource
+      |> Query.new()
+      |> Query.set_context(auth_context())
+      |> Query.for_read(
+        strategy.sign_in_action_name,
+        %{strategy.identity_field => identity_value},
+        ash_opts
+      )
+      |> Ash.read()
+      |> handle_user_query_result(strategy)
+    end
+
+    defp handle_user_query_result({:ok, [user]}, _strategy), do: {:ok, user}
+
+    defp handle_user_query_result({:ok, []}, strategy),
+      do: {:error, auth_failed(strategy, :sign_in, "Query returned no users")}
+
+    defp handle_user_query_result({:ok, _}, strategy),
+      do: {:error, auth_failed(strategy, :sign_in, "Query returned too many users")}
+
+    defp handle_user_query_result({:error, %AuthenticationFailed{} = error}, _strategy),
+      do: {:error, error}
+
+    defp handle_user_query_result({:error, error}, strategy) when is_exception(error),
+      do: {:error, AuthenticationFailed.exception(strategy: strategy, caused_by: error)}
+
+    defp handle_user_query_result({:error, _}, strategy),
+      do: {:error, auth_failed(strategy, :sign_in, "Authentication failed")}
+
+    defp best_effort_update_sign_count(strategy, credential_id, new_count, tenant) do
+      update_sign_count(strategy, credential_id, new_count, tenant)
+      :ok
+    end
+
+    defp ensure_not_last_credential(strategy, credentials) do
+      if length(credentials) <= 1 do
+        {:error, auth_failed(strategy, :delete_credential, "Cannot delete the last credential")}
+      else
+        :ok
+      end
+    end
+
+    defp find_credential(strategy, credentials, credential_id) do
+      case Enum.find(credentials, &(&1.id == credential_id)) do
+        nil -> {:error, auth_failed(strategy, :delete_credential, "Credential not found")}
+        credential -> {:ok, credential}
+      end
+    end
+
+    defp destroy_credential(credential, opts) do
+      tenant = Keyword.get(opts, :tenant)
+      ash_opts = [authorize?: false]
+      ash_opts = if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
+
+      credential
+      |> Changeset.new()
+      |> Changeset.set_context(auth_context())
+      |> Ash.destroy(ash_opts)
+    end
+
+    defp build_ash_opts(strategy, opts, tenant) do
+      ash_opts =
+        opts
+        |> Keyword.take([:actor])
+        |> Keyword.put_new_lazy(:domain, fn -> Info.domain!(strategy.resource) end)
+
+      if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
+    end
+
+    defp auth_context, do: %{private: %{ash_authentication?: true}}
+
+    defp auth_failed(strategy, action, message) do
+      AuthenticationFailed.exception(
+        strategy: strategy,
+        caused_by: %{
+          module: __MODULE__,
+          strategy: strategy,
+          action: action,
+          message: message
+        }
+      )
+    end
+
+    defp base64_error(strategy, action) do
+      {:error, auth_failed(strategy, action, "Invalid base64 encoding in request parameters")}
+    end
+
+    defp store_credential(strategy, user, cred_data, sign_count, label, tenant) do
+      attrs = %{
+        credential_id: cred_data.credential_id,
+        public_key: cred_data.credential_public_key,
+        sign_count: sign_count,
+        label: label || "Security Key",
+        user_id: user.id
+      }
+
+      ash_opts = internal_ash_opts(tenant)
+
+      strategy.credential_resource
+      |> Changeset.new()
+      |> Changeset.set_context(auth_context())
+      |> Changeset.for_create(:create, attrs, ash_opts)
+      |> Ash.create()
+    end
+
+    defp update_sign_count(strategy, credential_id, new_count, tenant) do
+      ash_opts = internal_ash_opts(tenant)
+
+      strategy.credential_resource
+      |> Query.new()
+      |> Query.set_context(auth_context())
+      |> Query.for_read(:read, %{}, ash_opts)
+      |> Query.filter(credential_id == ^credential_id)
+      |> Ash.read_one()
+      |> case do
+        {:ok, nil} ->
+          :ok
+
+        {:ok, credential} ->
+          credential
+          |> Changeset.new()
+          |> Changeset.set_context(auth_context())
+          |> Changeset.for_update(
+            :update,
+            %{sign_count: new_count, last_used_at: DateTime.utc_now()},
+            ash_opts
+          )
+          |> Ash.update()
+          |> case do
+            {:ok, _} -> :ok
+            {:error, error} -> log_sign_count_failure(error)
+          end
+
+        {:error, error} ->
+          log_sign_count_failure(error)
+      end
+    end
+
+    defp log_sign_count_failure(error) do
+      Logger.warning("Failed to update WebAuthn sign count: #{inspect(error)}")
+      :ok
+    end
+
+    defp internal_ash_opts(tenant) do
+      ash_opts = [authorize?: false]
+      if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
+    end
+
+    defp maybe_generate_token(user, strategy, opts) do
+      if Info.authentication_tokens_enabled?(strategy.resource) do
+        case Jwt.token_for_user(user, %{"purpose" => "user"}, Keyword.take(opts, [:tenant])) do
+          {:ok, token, _claims} ->
+            {:ok, Ash.Resource.put_metadata(user, :token, token)}
+
+          {:error, error} ->
+            {:error, error}
+        end
+      else
+        {:ok, user}
+      end
+    end
+
+    defp safe_url_decode64(nil), do: :error
+
+    defp safe_url_decode64(value) when is_binary(value),
+      do: Base.url_decode64(value, padding: false)
+
+    defp safe_url_decode64(_), do: :error
+  else
+    def registration_challenge(strategy, _tenant),
+      do: missing_wax_dependency(strategy, :registration_challenge)
+
+    def authentication_challenge(strategy, _allow_credentials, _tenant),
+      do: missing_wax_dependency(strategy, :authentication_challenge)
+
+    def register(strategy, _params, _opts \\ []),
+      do: missing_wax_dependency(strategy, :register)
+
+    def sign_in(strategy, _params, _opts \\ []),
+      do: missing_wax_dependency(strategy, :sign_in)
+
+    def list_credentials(strategy, _user, _opts),
+      do: missing_wax_dependency(strategy, :list_credentials)
+
+    def delete_credential(strategy, _user, _credential_id, _opts),
+      do: missing_wax_dependency(strategy, :delete_credential)
+
+    def update_credential_label(strategy, _credential_id, _new_label, _opts),
+      do: missing_wax_dependency(strategy, :update_credential_label)
+
+    def add_credential(strategy, _params, _opts \\ []),
+      do: missing_wax_dependency(strategy, :add_credential)
+
+    defp missing_wax_dependency(strategy, action) do
+      {:error,
+       AuthenticationFailed.exception(
+         strategy: strategy,
+         caused_by: %{
+           module: __MODULE__,
+           strategy: strategy,
+           action: action,
+           message: "The WebAuthn strategy requires the optional `:wax_` dependency"
+         }
+       )}
     end
   end
-
-  defp safe_url_decode64(nil), do: :error
-
-  defp safe_url_decode64(value) when is_binary(value),
-    do: Base.url_decode64(value, padding: false)
-
-  defp safe_url_decode64(_), do: :error
 end

--- a/lib/ash_authentication/strategies/webauthn/cose_key.ex
+++ b/lib/ash_authentication/strategies/webauthn/cose_key.ex
@@ -20,41 +20,36 @@ defmodule AshAuthentication.Strategy.WebAuthn.CoseKey do
 
   @impl true
   def cast_input(value, _) when is_map(value), do: {:ok, value}
-
-  def cast_input(value, _) when is_binary(value) do
-    if byte_size(value) > @max_cose_key_size do
-      :error
-    else
-      case CBOR.decode(value) do
-        {:ok, decoded, _} when is_map(decoded) -> {:ok, decoded}
-        _ -> :error
-      end
-    end
-  end
-
+  def cast_input(value, _) when is_binary(value), do: cast_cose_key(value)
   def cast_input(nil, _), do: {:ok, nil}
   def cast_input(_, _), do: :error
 
   @impl true
-  def dump_to_native(value, _) when is_map(value) do
-    {:ok, CBOR.encode(value) |> IO.iodata_to_binary()}
-  end
-
+  def dump_to_native(value, _) when is_map(value), do: dump_cose_key(value)
   def dump_to_native(nil, _), do: {:ok, nil}
   def dump_to_native(_, _), do: :error
 
   @impl true
-  def cast_stored(value, _) when is_binary(value) do
-    if byte_size(value) > @max_cose_key_size do
-      :error
-    else
-      case CBOR.decode(value) do
-        {:ok, decoded, _} when is_map(decoded) -> {:ok, decoded}
-        _ -> :error
-      end
-    end
-  end
-
+  def cast_stored(value, _) when is_binary(value), do: cast_cose_key(value)
   def cast_stored(nil, _), do: {:ok, nil}
   def cast_stored(_, _), do: :error
+
+  if Code.ensure_loaded?(CBOR) do
+    defp cast_cose_key(value) do
+      if byte_size(value) > @max_cose_key_size do
+        :error
+      else
+        case CBOR.decode(value) do
+          {:ok, decoded, _} when is_map(decoded) -> {:ok, decoded}
+          _ -> :error
+        end
+      end
+    end
+
+    defp dump_cose_key(value), do: {:ok, CBOR.encode(value) |> IO.iodata_to_binary()}
+  else
+    defp cast_cose_key(value) when byte_size(value) > @max_cose_key_size, do: :error
+    defp cast_cose_key(_value), do: :error
+    defp dump_cose_key(_value), do: :error
+  end
 end

--- a/lib/ash_authentication/strategies/webauthn/plug.ex
+++ b/lib/ash_authentication/strategies/webauthn/plug.ex
@@ -2,310 +2,357 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAuthentication.Strategy.WebAuthn.Plug do
-  @moduledoc """
-  Plug handlers for the WebAuthn strategy.
+if Code.ensure_loaded?(Wax.Challenge) do
+  defmodule AshAuthentication.Strategy.WebAuthn.Plug do
+    @moduledoc """
+    Plug handlers for the WebAuthn strategy.
 
-  Handles registration challenges, registration, authentication challenges,
-  and authentication via HTTP requests. Challenges are stored in the Plug session.
-  """
+    Handles registration challenges, registration, authentication challenges,
+    and authentication via HTTP requests. Challenges are stored in the Plug session.
+    """
 
-  alias AshAuthentication.{Errors.AuthenticationFailed, Info, Strategy, Strategy.WebAuthn}
-  alias Plug.Conn
-  import Ash.PlugHelpers, only: [get_actor: 1, get_tenant: 1, get_context: 1]
-  import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
-  import Ash.Expr, only: [ref: 1]
-  require Ash.Query
-  require Logger
+    alias AshAuthentication.{Errors.AuthenticationFailed, Info, Strategy, Strategy.WebAuthn}
+    alias Plug.Conn
+    import Ash.PlugHelpers, only: [get_actor: 1, get_tenant: 1, get_context: 1]
+    import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
+    import Ash.Expr, only: [ref: 1]
+    require Ash.Query
+    require Logger
 
-  @session_key "webauthn_challenge"
+    @session_key "webauthn_challenge"
 
-  @doc "Generate and return a registration challenge."
-  @spec registration_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def registration_challenge(conn, strategy) do
-    tenant = get_tenant(conn)
-    {:ok, challenge} = WebAuthn.Actions.registration_challenge(strategy, tenant)
+    @doc "Generate and return a registration challenge."
+    @spec registration_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def registration_challenge(conn, strategy) do
+      tenant = get_tenant(conn)
+      {:ok, challenge} = WebAuthn.Actions.registration_challenge(strategy, tenant)
 
-    rp_id = WebAuthn.Helpers.resolve_rp_id(strategy, tenant)
-    rp_name = WebAuthn.Helpers.resolve_rp_name(strategy, tenant)
+      rp_id = WebAuthn.Helpers.resolve_rp_id(strategy, tenant)
+      rp_name = WebAuthn.Helpers.resolve_rp_name(strategy, tenant)
 
-    response = %{
-      challenge: Base.url_encode64(challenge.bytes, padding: false),
-      rp: %{id: rp_id, name: rp_name},
-      authenticatorSelection: %{
-        authenticatorAttachment: strategy.authenticator_attachment,
+      response = %{
+        challenge: Base.url_encode64(challenge.bytes, padding: false),
+        rp: %{id: rp_id, name: rp_name},
+        authenticatorSelection: %{
+          authenticatorAttachment: strategy.authenticator_attachment,
+          userVerification: strategy.user_verification,
+          residentKey: strategy.resident_key
+        },
+        attestation: strategy.attestation,
+        timeout: strategy.timeout
+      }
+
+      # Store challenge as serializable map (not struct) for cookie session stores
+      challenge_data = %{
+        bytes: Base.encode64(challenge.bytes),
+        type: challenge.type,
+        origin: challenge.origin,
+        rp_id: challenge.rp_id,
+        issued_at: challenge.issued_at
+      }
+
+      conn
+      |> Conn.put_session(@session_key, challenge_data)
+      |> Conn.put_resp_content_type("application/json")
+      |> Conn.send_resp(200, Jason.encode!(response))
+    end
+
+    @doc "Handle a registration request."
+    @spec register(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def register(conn, strategy) do
+      case reconstruct_challenge(conn, :attestation, strategy) do
+        nil ->
+          conn
+          |> Conn.delete_session(@session_key)
+          |> store_authentication_result(missing_challenge_error(strategy, :register))
+
+        challenge ->
+          conn = Conn.delete_session(conn, @session_key)
+          params = subject_params(conn, strategy)
+          opts = opts(conn) ++ [challenge: challenge]
+          result = Strategy.action(strategy, :register, params, opts)
+          store_authentication_result(conn, result)
+      end
+    end
+
+    @doc "Generate and return an authentication challenge."
+    @spec authentication_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def authentication_challenge(conn, strategy) do
+      tenant = get_tenant(conn)
+      params = conn.params
+      identity_value = params[to_string(strategy.identity_field)]
+
+      # FIXED: Look up credentials for a SPECIFIC user, not all credentials
+      allow_credentials =
+        if identity_value do
+          lookup_user_credentials(strategy, identity_value, tenant)
+        else
+          # Discoverable credential flow (passkeys) - no allow_credentials needed
+          []
+        end
+
+      {:ok, challenge} =
+        WebAuthn.Actions.authentication_challenge(strategy, allow_credentials, tenant)
+
+      response = %{
+        challenge: Base.url_encode64(challenge.bytes, padding: false),
+        rpId: WebAuthn.Helpers.resolve_rp_id(strategy, tenant),
         userVerification: strategy.user_verification,
-        residentKey: strategy.resident_key
-      },
-      attestation: strategy.attestation,
-      timeout: strategy.timeout
-    }
+        timeout: strategy.timeout,
+        allowCredentials:
+          Enum.map(allow_credentials, fn {cred_id, _key} ->
+            %{id: Base.url_encode64(cred_id, padding: false), type: "public-key"}
+          end)
+      }
 
-    # Store challenge as serializable map (not struct) for cookie session stores
-    challenge_data = %{
-      bytes: Base.encode64(challenge.bytes),
-      type: challenge.type,
-      origin: challenge.origin,
-      rp_id: challenge.rp_id,
-      issued_at: challenge.issued_at
-    }
+      # Store challenge as serializable map
+      challenge_data = %{
+        bytes: Base.encode64(challenge.bytes),
+        type: challenge.type,
+        origin: challenge.origin,
+        rp_id: challenge.rp_id,
+        allow_credentials:
+          Enum.map(allow_credentials, fn {cred_id, cose_key} ->
+            {Base.encode64(cred_id), cose_key}
+          end),
+        issued_at: challenge.issued_at
+      }
 
-    conn
-    |> Conn.put_session(@session_key, challenge_data)
-    |> Conn.put_resp_content_type("application/json")
-    |> Conn.send_resp(200, Jason.encode!(response))
-  end
+      conn
+      |> Conn.put_session(@session_key, challenge_data)
+      |> Conn.put_resp_content_type("application/json")
+      |> Conn.send_resp(200, Jason.encode!(response))
+    end
 
-  @doc "Handle a registration request."
-  @spec register(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def register(conn, strategy) do
-    case reconstruct_challenge(conn, :attestation, strategy) do
-      nil ->
-        conn
-        |> Conn.delete_session(@session_key)
-        |> store_authentication_result(missing_challenge_error(strategy, :register))
+    @doc "Handle an authentication request."
+    @spec sign_in(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def sign_in(conn, strategy) do
+      case reconstruct_challenge(conn, :authentication, strategy) do
+        nil ->
+          conn
+          |> Conn.delete_session(@session_key)
+          |> store_authentication_result(missing_challenge_error(strategy, :sign_in))
 
-      challenge ->
+        challenge ->
+          conn = Conn.delete_session(conn, @session_key)
+          params = subject_params(conn, strategy)
+          opts = opts(conn) ++ [challenge: challenge]
+          result = Strategy.action(strategy, :sign_in, params, opts)
+          store_authentication_result(conn, result)
+      end
+    end
+
+    @doc """
+    Generate and return a registration challenge for adding a credential to the
+    current user.
+
+    Requires an authenticated actor on the connection.
+    """
+    @spec add_credential_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def add_credential_challenge(conn, strategy) do
+      case get_actor(conn) do
+        nil ->
+          store_authentication_result(conn, unauthenticated_error(strategy, :add_credential))
+
+        _actor ->
+          registration_challenge(conn, strategy)
+      end
+    end
+
+    @doc """
+    Handle an `add_credential` request — attach a new credential to the
+    authenticated user.
+
+    Requires an authenticated actor on the connection.
+    """
+    @spec add_credential(Conn.t(), WebAuthn.t()) :: Conn.t()
+    def add_credential(conn, strategy) do
+      with actor when not is_nil(actor) <- get_actor(conn),
+           %Wax.Challenge{} = challenge <- reconstruct_challenge(conn, :attestation, strategy) do
         conn = Conn.delete_session(conn, @session_key)
         params = subject_params(conn, strategy)
-        opts = opts(conn) ++ [challenge: challenge]
-        result = Strategy.action(strategy, :register, params, opts)
+        opts = opts(conn) ++ [challenge: challenge, user: actor]
+        result = WebAuthn.Actions.add_credential(strategy, params, opts)
         store_authentication_result(conn, result)
-    end
-  end
-
-  @doc "Generate and return an authentication challenge."
-  @spec authentication_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def authentication_challenge(conn, strategy) do
-    tenant = get_tenant(conn)
-    params = conn.params
-    identity_value = params[to_string(strategy.identity_field)]
-
-    # FIXED: Look up credentials for a SPECIFIC user, not all credentials
-    allow_credentials =
-      if identity_value do
-        lookup_user_credentials(strategy, identity_value, tenant)
       else
-        # Discoverable credential flow (passkeys) - no allow_credentials needed
-        []
+        nil ->
+          store_authentication_result(conn, unauthenticated_error(strategy, :add_credential))
+
+        _ ->
+          conn
+          |> Conn.delete_session(@session_key)
+          |> store_authentication_result(missing_challenge_error(strategy, :add_credential))
       end
-
-    {:ok, challenge} =
-      WebAuthn.Actions.authentication_challenge(strategy, allow_credentials, tenant)
-
-    response = %{
-      challenge: Base.url_encode64(challenge.bytes, padding: false),
-      rpId: WebAuthn.Helpers.resolve_rp_id(strategy, tenant),
-      userVerification: strategy.user_verification,
-      timeout: strategy.timeout,
-      allowCredentials:
-        Enum.map(allow_credentials, fn {cred_id, _key} ->
-          %{id: Base.url_encode64(cred_id, padding: false), type: "public-key"}
-        end)
-    }
-
-    # Store challenge as serializable map
-    challenge_data = %{
-      bytes: Base.encode64(challenge.bytes),
-      type: challenge.type,
-      origin: challenge.origin,
-      rp_id: challenge.rp_id,
-      allow_credentials:
-        Enum.map(allow_credentials, fn {cred_id, cose_key} ->
-          {Base.encode64(cred_id), cose_key}
-        end),
-      issued_at: challenge.issued_at
-    }
-
-    conn
-    |> Conn.put_session(@session_key, challenge_data)
-    |> Conn.put_resp_content_type("application/json")
-    |> Conn.send_resp(200, Jason.encode!(response))
-  end
-
-  @doc "Handle an authentication request."
-  @spec sign_in(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def sign_in(conn, strategy) do
-    case reconstruct_challenge(conn, :authentication, strategy) do
-      nil ->
-        conn
-        |> Conn.delete_session(@session_key)
-        |> store_authentication_result(missing_challenge_error(strategy, :sign_in))
-
-      challenge ->
-        conn = Conn.delete_session(conn, @session_key)
-        params = subject_params(conn, strategy)
-        opts = opts(conn) ++ [challenge: challenge]
-        result = Strategy.action(strategy, :sign_in, params, opts)
-        store_authentication_result(conn, result)
     end
-  end
 
-  @doc """
-  Generate and return a registration challenge for adding a credential to the
-  current user.
-
-  Requires an authenticated actor on the connection.
-  """
-  @spec add_credential_challenge(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def add_credential_challenge(conn, strategy) do
-    case get_actor(conn) do
-      nil ->
-        store_authentication_result(conn, unauthenticated_error(strategy, :add_credential))
-
-      _actor ->
-        registration_challenge(conn, strategy)
-    end
-  end
-
-  @doc """
-  Handle an `add_credential` request — attach a new credential to the
-  authenticated user.
-
-  Requires an authenticated actor on the connection.
-  """
-  @spec add_credential(Conn.t(), WebAuthn.t()) :: Conn.t()
-  def add_credential(conn, strategy) do
-    with actor when not is_nil(actor) <- get_actor(conn),
-         %Wax.Challenge{} = challenge <- reconstruct_challenge(conn, :attestation, strategy) do
-      conn = Conn.delete_session(conn, @session_key)
-      params = subject_params(conn, strategy)
-      opts = opts(conn) ++ [challenge: challenge, user: actor]
-      result = WebAuthn.Actions.add_credential(strategy, params, opts)
-      store_authentication_result(conn, result)
-    else
-      nil ->
-        store_authentication_result(conn, unauthenticated_error(strategy, :add_credential))
-
-      _ ->
-        conn
-        |> Conn.delete_session(@session_key)
-        |> store_authentication_result(missing_challenge_error(strategy, :add_credential))
-    end
-  end
-
-  defp unauthenticated_error(strategy, action) do
-    {:error,
-     AuthenticationFailed.exception(
-       strategy: strategy,
-       caused_by: %{
-         module: __MODULE__,
+    defp unauthenticated_error(strategy, action) do
+      {:error,
+       AuthenticationFailed.exception(
          strategy: strategy,
-         action: action,
-         message: "An authenticated user is required to add a credential"
-       }
-     )}
-  end
+         caused_by: %{
+           module: __MODULE__,
+           strategy: strategy,
+           action: action,
+           message: "An authenticated user is required to add a credential"
+         }
+       )}
+    end
 
-  defp missing_challenge_error(strategy, action) do
-    {:error,
-     AuthenticationFailed.exception(
-       strategy: strategy,
-       caused_by: %{
-         module: __MODULE__,
+    defp missing_challenge_error(strategy, action) do
+      {:error,
+       AuthenticationFailed.exception(
          strategy: strategy,
-         action: action,
-         message: "Missing or invalid WebAuthn challenge in session"
-       }
-     )}
-  end
-
-  # Reconstruct a Wax.Challenge from the serialized session data.
-  # We store challenges as plain maps because cookie session stores
-  # cannot serialize arbitrary Elixir structs.
-  defp reconstruct_challenge(conn, type, strategy) do
-    with %{} = data <- Conn.get_session(conn, @session_key),
-         {:ok, bytes} <- Base.decode64(data["bytes"] || data[:bytes]) do
-      build_challenge(data, bytes, type, strategy)
-    else
-      _ -> nil
+         caused_by: %{
+           module: __MODULE__,
+           strategy: strategy,
+           action: action,
+           message: "Missing or invalid WebAuthn challenge in session"
+         }
+       )}
     end
-  end
 
-  defp build_challenge(data, bytes, type, strategy) do
-    base = %Wax.Challenge{
-      type: type,
-      bytes: bytes,
-      origin: data["origin"] || data[:origin],
-      rp_id: data["rp_id"] || data[:rp_id],
-      issued_at: data["issued_at"] || data[:issued_at],
-      origin_verify_fun: {Wax, :origins_match?, []}
-    }
-
-    case type do
-      :attestation ->
-        %{
-          base
-          | attestation: strategy.attestation,
-            trusted_attestation_types: [:none, :basic, :self, :uncertain],
-            verify_trust_root: false
-        }
-
-      _ ->
-        %{base | allow_credentials: decode_allow_credentials(data)}
-    end
-  end
-
-  defp decode_allow_credentials(data) do
-    (data["allow_credentials"] || data[:allow_credentials] || [])
-    |> Enum.flat_map(fn {encoded_id, cose_key} ->
-      case Base.decode64(encoded_id) do
-        {:ok, decoded_id} -> [{decoded_id, cose_key}]
-        :error -> []
+    # Reconstruct a Wax.Challenge from the serialized session data.
+    # We store challenges as plain maps because cookie session stores
+    # cannot serialize arbitrary Elixir structs.
+    defp reconstruct_challenge(conn, type, strategy) do
+      with %{} = data <- Conn.get_session(conn, @session_key),
+           {:ok, bytes} <- Base.decode64(data["bytes"] || data[:bytes]) do
+        build_challenge(data, bytes, type, strategy)
+      else
+        _ -> nil
       end
-    end)
-  end
+    end
 
-  defp subject_params(conn, strategy) do
-    subject_name =
-      strategy.resource
-      |> Info.authentication_subject_name!()
-      |> to_string()
+    defp build_challenge(data, bytes, type, strategy) do
+      base = %Wax.Challenge{
+        type: type,
+        bytes: bytes,
+        origin: data["origin"] || data[:origin],
+        rp_id: data["rp_id"] || data[:rp_id],
+        issued_at: data["issued_at"] || data[:issued_at],
+        origin_verify_fun: {Wax, :origins_match?, []}
+      }
 
-    Map.get(conn.params, subject_name, %{})
-  end
+      case type do
+        :attestation ->
+          %{
+            base
+            | attestation: strategy.attestation,
+              trusted_attestation_types: [:none, :basic, :self, :uncertain],
+              verify_trust_root: false
+          }
 
-  defp opts(conn) do
-    [actor: get_actor(conn), tenant: get_tenant(conn), context: get_context(conn)]
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-  end
+        _ ->
+          %{base | allow_credentials: decode_allow_credentials(data)}
+      end
+    end
 
-  # FIXED: Look up credentials for a SPECIFIC user by identity field.
-  # The original version read ALL credentials for ALL users.
-  defp lookup_user_credentials(strategy, identity_value, tenant) do
-    context = %{private: %{ash_authentication?: true}}
-    ash_opts = [authorize?: false]
-    ash_opts = if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
-
-    identity_field = strategy.identity_field
-
-    # First find the user by identity
-    with {:ok, user} when not is_nil(user) <-
-           strategy.resource
-           |> Ash.Query.new()
-           |> Ash.Query.set_context(context)
-           |> Ash.Query.filter(^ref(identity_field) == ^identity_value)
-           |> Ash.Query.for_read(:read, %{}, ash_opts)
-           |> Ash.read_one(),
-         # Then load their credentials via the relationship
-         {:ok, user} <-
-           Ash.load(user, [strategy.credentials_relationship_name], ash_opts) do
-      user
-      |> Map.get(strategy.credentials_relationship_name, [])
-      |> Enum.map(fn cred ->
-        {Map.get(cred, strategy.credential_id_field), Map.get(cred, strategy.public_key_field)}
+    defp decode_allow_credentials(data) do
+      (data["allow_credentials"] || data[:allow_credentials] || [])
+      |> Enum.flat_map(fn {encoded_id, cose_key} ->
+        case Base.decode64(encoded_id) do
+          {:ok, decoded_id} -> [{decoded_id, cose_key}]
+          :error -> []
+        end
       end)
-    else
-      _ -> []
     end
-  rescue
-    error in [
-      Ash.Error.Invalid,
-      Ash.Error.Forbidden,
-      Ash.Error.Framework,
-      Ash.Error.Unknown
-    ] ->
-      Logger.warning("WebAuthn credential lookup failed: #{Exception.message(error)}")
-      []
+
+    defp subject_params(conn, strategy) do
+      subject_name =
+        strategy.resource
+        |> Info.authentication_subject_name!()
+        |> to_string()
+
+      Map.get(conn.params, subject_name, %{})
+    end
+
+    defp opts(conn) do
+      [actor: get_actor(conn), tenant: get_tenant(conn), context: get_context(conn)]
+      |> Enum.reject(&is_nil(elem(&1, 1)))
+    end
+
+    # FIXED: Look up credentials for a SPECIFIC user by identity field.
+    # The original version read ALL credentials for ALL users.
+    defp lookup_user_credentials(strategy, identity_value, tenant) do
+      context = %{private: %{ash_authentication?: true}}
+      ash_opts = [authorize?: false]
+      ash_opts = if tenant, do: Keyword.put(ash_opts, :tenant, tenant), else: ash_opts
+
+      identity_field = strategy.identity_field
+
+      # First find the user by identity
+      with {:ok, user} when not is_nil(user) <-
+             strategy.resource
+             |> Ash.Query.new()
+             |> Ash.Query.set_context(context)
+             |> Ash.Query.filter(^ref(identity_field) == ^identity_value)
+             |> Ash.Query.for_read(:read, %{}, ash_opts)
+             |> Ash.read_one(),
+           # Then load their credentials via the relationship
+           {:ok, user} <-
+             Ash.load(user, [strategy.credentials_relationship_name], ash_opts) do
+        user
+        |> Map.get(strategy.credentials_relationship_name, [])
+        |> Enum.map(fn cred ->
+          {Map.get(cred, strategy.credential_id_field), Map.get(cred, strategy.public_key_field)}
+        end)
+      else
+        _ -> []
+      end
+    rescue
+      error in [
+        Ash.Error.Invalid,
+        Ash.Error.Forbidden,
+        Ash.Error.Framework,
+        Ash.Error.Unknown
+      ] ->
+        Logger.warning("WebAuthn credential lookup failed: #{Exception.message(error)}")
+        []
+    end
+  end
+else
+  defmodule AshAuthentication.Strategy.WebAuthn.Plug do
+    @moduledoc """
+    Plug handlers for the WebAuthn strategy.
+
+    The WebAuthn plug requires the optional `:wax_` dependency.
+    """
+
+    alias AshAuthentication.Errors.AuthenticationFailed
+    import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
+
+    def registration_challenge(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :registration_challenge)
+
+    def register(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :register)
+
+    def authentication_challenge(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :authentication_challenge)
+
+    def sign_in(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :sign_in)
+
+    def add_credential_challenge(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :add_credential_challenge)
+
+    def add_credential(conn, strategy),
+      do: missing_wax_dependency(conn, strategy, :add_credential)
+
+    defp missing_wax_dependency(conn, strategy, action) do
+      store_authentication_result(
+        conn,
+        {:error,
+         AuthenticationFailed.exception(
+           strategy: strategy,
+           caused_by: %{
+             module: __MODULE__,
+             strategy: strategy,
+             action: action,
+             message: "The WebAuthn strategy requires the optional `:wax_` dependency"
+           }
+         )}
+      )
+    end
   end
 end

--- a/lib/ash_authentication/strategies/webauthn/verifier.ex
+++ b/lib/ash_authentication/strategies/webauthn/verifier.ex
@@ -16,11 +16,34 @@ defmodule AshAuthentication.Strategy.WebAuthn.Verifier do
   @doc false
   @spec verify(WebAuthn.t(), map) :: :ok | {:error, Exception.t()}
   def verify(strategy, dsl_state) do
-    with :ok <- validate_rp_id(strategy),
+    with :ok <- validate_wax_dependency(),
+         :ok <- validate_rp_id(strategy),
          :ok <- validate_credential_resource(strategy),
          :ok <- validate_credentials_relationship(strategy, dsl_state),
          :ok <- validate_credential_resource_shape(strategy) do
       validate_tokens_enabled(dsl_state)
+    end
+  end
+
+  defp validate_wax_dependency do
+    if Code.ensure_loaded?(Wax) do
+      :ok
+    else
+      {:error,
+       DslError.exception(
+         path: [:authentication, :strategies, :webauthn],
+         message: """
+         The WebAuthn strategy requires the optional `:wax_` dependency.
+
+         Add it to your dependencies:
+
+             {:wax_, "~> 0.7"}
+
+         If `ash_authentication` was already compiled without `:wax_`, recompile it:
+
+             mix deps.compile ash_authentication --force
+         """
+       )}
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes compilation of downstream apps that depend on `ash_authentication` without `:wax_`, even when they do not use WebAuthn.

`wax_` remains required for WebAuthn itself. The real WebAuthn `Actions`/`Plug` implementations, Wax struct usage, and CBOR calls now compile only when the optional dependency is available. Configuring WebAuthn without `:wax_` now raises a clearer verifier error with the dependency and recompile steps.

## Test plan

- [x] `mix test test/ash_authentication/strategies/webauthn/plug_test.exs test/ash_authentication/strategies/webauthn/actions_test.exs test/ash_authentication/strategies/webauthn/cose_key_test.exs`
- [x] `mix deps.compile ash_authentication --force` in a parent app without `:wax_`
- [x] `mix compile` in the parent app