### PR TITLE
fix: register `Ash.Policy.Authorizer` on the WebAuthn credential resource

### DIFF
--- a/lib/mix/tasks/ash_authentication.add_strategy.webauthn.ex
+++ b/lib/mix/tasks/ash_authentication.add_strategy.webauthn.ex
@@ -258,9 +258,9 @@ if Code.ensure_loaded?(Igniter) do
 
     defp data_layer_extension do
       cond do
-        Code.ensure_loaded?(AshPostgres.DataLayer) -> "postgres"
-        Code.ensure_loaded?(AshSqlite.DataLayer) -> "sqlite"
-        true -> ""
+        Code.ensure_loaded?(AshPostgres.DataLayer) -> "Ash.Policy.Authorizer,postgres"
+        Code.ensure_loaded?(AshSqlite.DataLayer) -> "Ash.Policy.Authorizer,sqlite"
+        true -> "Ash.Policy.Authorizer"
       end
     end
   end

--- a/test/mix/tasks/ash_authentication.add_strategy.webauthn_test.exs
+++ b/test/mix/tasks/ash_authentication.add_strategy.webauthn_test.exs
@@ -68,6 +68,14 @@ defmodule Mix.Tasks.AshAuthentication.AddStrategy.WebauthnTest do
     assert diff(result) =~ "AshAuthentication.Checks.AshAuthenticationInteraction"
   end
 
+  test "credential resource registers Ash.Policy.Authorizer", %{igniter: igniter} do
+    result =
+      igniter
+      |> Igniter.compose_task("ash_authentication.add_strategy.webauthn", @args)
+
+    assert diff(result) =~ "authorizers: [Ash.Policy.Authorizer]"
+  end
+
   test "adds the has_many :webauthn_credentials relationship to the user", %{igniter: igniter} do
     result =
       igniter


### PR DESCRIPTION
The WebAuthn igniter (#1160) generates a credential resource with a `policies` block containing the `AshAuthenticationInteraction` bypass, but it doesn't register `Ash.Policy.Authorizer` as an authorizer on the resource. Without that, the policy block is silently ignored — the bypass doesn't bypass anything because there's no policy enforcement happening in the first place.

Pass `Ash.Policy.Authorizer` through to `ash.gen.resource` alongside the data-layer extension, matching the api_key igniter's pattern.

## Test plan

- [x] New test asserts `authorizers: [Ash.Policy.Authorizer]` in the credential resource
- [x] 9 generator tests, 0 failures