### PR TITLE
Dynamic OIDC feedback

### DIFF
--- a/lib/ash_authentication/strategies/dynamic_oidc/plug.ex
+++ b/lib/ash_authentication/strategies/dynamic_oidc/plug.ex
@@ -20,7 +20,6 @@ defmodule AshAuthentication.Strategy.DynamicOidc.Plug do
   alias Ash.Error.Framework.AssumptionFailed
   alias AshAuthentication.{Errors, Info, OidcConnection, Strategy.DynamicOidc, Strategy.OAuth2}
   alias Plug.Conn
-  alias Spark.Dsl.Extension
   import Ash.PlugHelpers, only: [get_actor: 1, get_tenant: 1, get_context: 1]
   import AshAuthentication.Plug.Helpers, only: [store_authentication_result: 2]
   import Plug.Conn
@@ -121,21 +120,21 @@ defmodule AshAuthentication.Strategy.DynamicOidc.Plug do
   end
 
   defp field_names(strategy) do
-    dsl_state = Extension.get_persisted(strategy.connection_resource, :spark_dsl_config)
+    resource = strategy.connection_resource
 
     [
-      OidcConnection.Info.oidc_connection_base_url_field!(dsl_state),
-      OidcConnection.Info.oidc_connection_client_id_field!(dsl_state),
-      OidcConnection.Info.oidc_connection_client_secret_field!(dsl_state)
+      OidcConnection.Info.oidc_connection_base_url_field!(resource),
+      OidcConnection.Info.oidc_connection_client_id_field!(resource),
+      OidcConnection.Info.oidc_connection_client_secret_field!(resource)
     ]
   end
 
   defp merge_connection_into_strategy(strategy, connection) do
-    dsl_state = Extension.get_persisted(strategy.connection_resource, :spark_dsl_config)
+    resource = strategy.connection_resource
 
-    base_url_field = OidcConnection.Info.oidc_connection_base_url_field!(dsl_state)
-    client_id_field = OidcConnection.Info.oidc_connection_client_id_field!(dsl_state)
-    client_secret_field = OidcConnection.Info.oidc_connection_client_secret_field!(dsl_state)
+    base_url_field = OidcConnection.Info.oidc_connection_base_url_field!(resource)
+    client_id_field = OidcConnection.Info.oidc_connection_client_id_field!(resource)
+    client_secret_field = OidcConnection.Info.oidc_connection_client_secret_field!(resource)
 
     {:ok,
      %{

--- a/lib/ash_authentication/strategies/oauth2/actions.ex
+++ b/lib/ash_authentication/strategies/oauth2/actions.ex
@@ -16,7 +16,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Actions do
   Attempt to sign in a user.
   """
   @spec sign_in(OAuth2.t(), map, keyword) :: {:ok, Resource.record()} | {:error, any}
-  def sign_in(%OAuth2{} = strategy, _params, _options) when strategy.registration_enabled?,
+  def sign_in(strategy, _params, _options) when strategy.registration_enabled?,
     do:
       {:error,
        NoSuchAction.exception(
@@ -25,7 +25,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Actions do
          type: :read
        )}
 
-  def sign_in(%OAuth2{} = strategy, params, options) do
+  def sign_in(strategy, params, options) do
     options =
       options
       |> Keyword.put_new_lazy(:domain, fn -> Info.domain!(strategy.resource) end)
@@ -95,7 +95,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Actions do
   Attempt to register a new user.
   """
   @spec register(OAuth2.t(), map, keyword) :: {:ok, Resource.record()} | {:error, any}
-  def register(%OAuth2{} = strategy, params, options) when strategy.registration_enabled? do
+  def register(strategy, params, options) when strategy.registration_enabled? do
     action = Resource.Info.action(strategy.resource, strategy.register_action_name, :create)
 
     options =


### PR DESCRIPTION
Hi @zachdaniel 👋 

I tested out this branch on an existing app that was using an OAuth2 strategy with Google.
The commit was da62bd4b5ac8bba2f750d57d59706c36257291fd. 

To get it working I had to make the following changes:

1. Use `strategy.connection_resource` directly rather than `Extension.get_persisted(strategy.connection_resource, :spark_dsl_config)` for the `OidcConnection.Info.oidc_connection_*` calls. Not sure what the implications of that are, but the `dsl_state` was coming back as `nil`. 


2. Remove struct pattern matching on the oauth2 actions, when they're called from the `DynamicOIDC` strategy the struct is `%DynamicOidc{}` so the matches fail. 

I also had to add this custom plug to inject the `connection_id` into the `path_params` on the `Conn` so that `AshAuthentication.Strategy.DynamicOidc.Plug` could pick it up from the expected place:


```elixir
  @behaviour Plug

  @impl true
  def init(opts), do: opts

  @impl true
  def call(
        %Plug.Conn{path_info: ["auth", "user", "oidc", connection_id, "request"]} = conn,
        _opts
      ) do
    %{conn | path_params: Map.put(conn.path_params, "connection_id", connection_id)}
  end

  def call(conn, _opts), do: conn
```

Is that something we should update the `StrategyRouter` in `AshAuthenticationPhoenix` to handle? 
The router is currently defined using the `auth_routes` macro like:

```elixir
  scope "/", MyAppWeb do
    pipe_through :browser

    auth_routes AuthController, MyApp.Accounts.User, path: "/auth"
    sign_out_route AuthController

    sign_in_route ...
```

Or should I be explicitly defining those routes in the router to get the `connection_id` path parameter binding?