### PR TITLE
fix: propagate Ash context opts in TOTP pending setup and confirm_setup

### DIFF
--- a/lib/ash_authentication/strategies/totp/confirm_setup_change.ex
+++ b/lib/ash_authentication/strategies/totp/confirm_setup_change.ex
@@ -29,10 +29,12 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
 
   @doc false
   @impl true
-  def change(changeset, _context, _opts) do
+  def change(changeset, _opts, context) do
+    context_opts = Ash.Context.to_opts(context)
+
     case Info.strategy_for_action(changeset.resource, changeset.action.name) do
       {:ok, strategy} ->
-        do_change(changeset, strategy)
+        do_change(changeset, strategy, context_opts, context)
 
       :error ->
         raise AssumptionFailed,
@@ -40,7 +42,7 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
     end
   end
 
-  defp do_change(changeset, strategy) do
+  defp do_change(changeset, strategy, context_opts, context) do
     changeset
     |> Changeset.set_context(%{private: %{ash_authentication?: true}})
     |> Changeset.before_action(fn changeset ->
@@ -48,7 +50,7 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
       code = Changeset.get_argument(changeset, :code)
 
       with :ok <- validate_code_format(code, strategy),
-           {:ok, secret} <- verify_token_and_get_secret(setup_token, strategy),
+           {:ok, secret} <- verify_token_and_get_secret(setup_token, strategy, context_opts, context),
            :ok <- verify_code(secret, code, strategy) do
         changeset
         |> Changeset.force_change_attribute(strategy.secret_field, secret)
@@ -58,19 +60,19 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
           Changeset.add_error(changeset, reason)
       end
     end)
-    |> Changeset.after_action(&maybe_revoke_setup_token(&1, &2, strategy))
+    |> Changeset.after_action(&maybe_revoke_setup_token(&1, &2, strategy, context_opts))
     |> Changeset.after_action(&preserve_authentication_metadata/2)
   end
 
-  defp maybe_revoke_setup_token(changeset, result, strategy) do
+  defp maybe_revoke_setup_token(changeset, result, strategy, context_opts) do
     case changeset.context[:setup_token_to_revoke] do
       nil -> {:ok, result}
-      setup_token -> revoke_token_for_result(setup_token, result, strategy)
+      setup_token -> revoke_token_for_result(setup_token, result, strategy, context_opts)
     end
   end
 
-  defp revoke_token_for_result(setup_token, result, strategy) do
-    case revoke_token(setup_token, strategy) do
+  defp revoke_token_for_result(setup_token, result, strategy, context_opts) do
+    case revoke_token(setup_token, strategy, context_opts) do
       :ok -> {:ok, result}
       {:error, reason} -> {:error, reason}
     end
@@ -83,14 +85,15 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
     end
   end
 
-  defp verify_token_and_get_secret(setup_token, strategy) do
-    with {:ok, %{"jti" => jti}, _resource} <- Jwt.verify(setup_token, strategy.resource),
+  defp verify_token_and_get_secret(setup_token, strategy, context_opts, context) do
+    with {:ok, %{"jti" => jti}, _resource} <-
+           Jwt.verify(setup_token, strategy.resource, context_opts, context),
          {:ok, token_resource} <- Info.authentication_tokens_token_resource(strategy.resource),
          {:ok, [token_record]} <-
            TokenResource.Actions.get_token(
              token_resource,
              %{"jti" => jti, "purpose" => "totp_setup"},
-             []
+             context_opts
            ),
          {:ok, encoded_secret} <- get_extra_data_secret(token_record) do
       case Base.decode64(encoded_secret) do
@@ -130,12 +133,16 @@ defmodule AshAuthentication.Strategy.Totp.ConfirmSetupChange do
     end
   end
 
-  defp revoke_token(setup_token, strategy) do
+  defp revoke_token(setup_token, strategy, context_opts) do
     with {:ok, token_resource} <- Info.authentication_tokens_token_resource(strategy.resource) do
       # TOTP setup tokens are always stored (with the pending secret in
       # `extra_data`) regardless of the `store_all_tokens?` flag, so we always
       # take the lock-and-update revocation path.
-      TokenResource.Actions.revoke(token_resource, setup_token, store_all_tokens?: true)
+      TokenResource.Actions.revoke(
+        token_resource,
+        setup_token,
+        Keyword.merge(context_opts, store_all_tokens?: true)
+      )
     end
   end
 

--- a/lib/ash_authentication/strategies/totp/generate_pending_setup_change.ex
+++ b/lib/ash_authentication/strategies/totp/generate_pending_setup_change.ex
@@ -25,10 +25,10 @@ defmodule AshAuthentication.Strategy.Totp.GeneratePendingSetupChange do
 
   @doc false
   @impl true
-  def change(changeset, _context, _opts) do
+  def change(changeset, _opts, context) do
     case Info.strategy_for_action(changeset.resource, changeset.action.name) do
       {:ok, strategy} ->
-        do_change(changeset, strategy)
+        do_change(changeset, strategy, Ash.Context.to_opts(context))
 
       :error ->
         raise AssumptionFailed,
@@ -36,12 +36,13 @@ defmodule AshAuthentication.Strategy.Totp.GeneratePendingSetupChange do
     end
   end
 
-  defp do_change(changeset, strategy) do
+  defp do_change(changeset, strategy, context_opts) do
     changeset
     |> Changeset.set_context(%{private: %{ash_authentication?: true}})
     |> Changeset.after_action(fn _changeset, user ->
       with {:ok, secret, totp_url} <- generate_secret_and_url(user, strategy),
-           {:ok, setup_token} <- generate_and_store_setup_token(user, secret, strategy) do
+           {:ok, setup_token} <-
+             generate_and_store_setup_token(user, secret, strategy, context_opts) do
         user =
           user
           |> Resource.put_metadata(:setup_token, setup_token)
@@ -65,15 +66,15 @@ defmodule AshAuthentication.Strategy.Totp.GeneratePendingSetupChange do
     {:ok, secret, totp_url}
   end
 
-  defp generate_and_store_setup_token(user, secret, strategy) do
+  defp generate_and_store_setup_token(user, secret, strategy, context_opts) do
+    jwt_opts =
+      Keyword.merge(context_opts,
+        purpose: :totp_setup,
+        token_lifetime: strategy.setup_token_lifetime
+      )
+
     with {:ok, token_resource} <- Info.authentication_tokens_token_resource(strategy.resource),
-         {:ok, token, _claims} <-
-           Jwt.token_for_user(
-             user,
-             %{},
-             purpose: :totp_setup,
-             token_lifetime: strategy.setup_token_lifetime
-           ) do
+         {:ok, token, _claims} <- Jwt.token_for_user(user, %{}, jwt_opts) do
       encoded_secret = Base.encode64(secret)
 
       case TokenResource.Actions.store_token(
@@ -83,7 +84,7 @@ defmodule AshAuthentication.Strategy.Totp.GeneratePendingSetupChange do
                "purpose" => "totp_setup",
                "extra_data" => %{"secret" => encoded_secret}
              },
-             []
+             context_opts
            ) do
         :ok -> {:ok, token}
         {:error, reason} -> {:error, reason}


### PR DESCRIPTION
## Summary

- Correct `Ash.Resource.Change` callback argument order (`opts`, then Ash `context`) for TOTP pending-setup and confirm-setup changes.
- Thread `Ash.Context.to_opts(context)` through pending-setup `Jwt.token_for_user` / `store_token`.
- Thread the same opts (and raw context for `Jwt.verify`) through confirm-setup `Jwt.verify`, `TokenResource.Actions.get_token`, and `revoke`, so multitenant token checks (e.g. JTI revocation) receive `:tenant`.


Made with [Cursor](https://cursor.com)