### PR TITLE
improvement: support `private_key` in Apple strategy

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.Strategy.Apple.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.Apple.md
@@ -13,7 +13,7 @@ In order to use Apple Sign In you need to provide the following minimum configur
   - `client_id`
   - `team_id`
   - `private_key_id`
-  - `private_key_path`
+  - `private_key_path` or `private_key`
   - `redirect_uri`
 
 ## More documentation:
@@ -66,7 +66,6 @@ The following defaults are applied:
 | [`redirect_uri`](#authentication-strategies-apple-redirect_uri){: #authentication-strategies-apple-redirect_uri .spark-required} | `(any, any -> any) \| module \| String.t` |  | The callback URI *base*. Not the whole URI back to the callback endpoint, but the URI to your `AuthPlug`. Takes either a module which implements the `AshAuthentication.Secret` behaviour, a 2 arity anonymous function or a string. |
 | [`team_id`](#authentication-strategies-apple-team_id){: #authentication-strategies-apple-team_id .spark-required} | `(any, any -> any) \| module \| String.t` |  | The Apple team ID associated with the application. |
 | [`private_key_id`](#authentication-strategies-apple-private_key_id){: #authentication-strategies-apple-private_key_id .spark-required} | `(any, any -> any) \| module \| String.t` |  | The private key ID used for signing the JWT token. |
-| [`private_key_path`](#authentication-strategies-apple-private_key_path){: #authentication-strategies-apple-private_key_path .spark-required} | `(any, any -> any) \| module \| String.t` |  | The path to the private key file used for signing the JWT token. |
 | [`site`](#authentication-strategies-apple-site){: #authentication-strategies-apple-site } | `(any, any -> any) \| module \| String.t` |  | Deprecated: Use `base_url` instead. |
 | [`prevent_hijacking?`](#authentication-strategies-apple-prevent_hijacking?){: #authentication-strategies-apple-prevent_hijacking? } | `boolean` | `true` | Requires a confirmation add_on to be present if the password strategy is used with the same identity_field. |
 | [`auth_method`](#authentication-strategies-apple-auth_method){: #authentication-strategies-apple-auth_method } | `nil \| :client_secret_basic \| :client_secret_post \| :client_secret_jwt \| :private_key_jwt` | `:client_secret_post` | The authentication strategy used, optional. If not set, no authentication will be used during the access token request. |
@@ -87,6 +86,7 @@ The following defaults are applied:
 | [`id_token_signed_response_alg`](#authentication-strategies-apple-id_token_signed_response_alg){: #authentication-strategies-apple-id_token_signed_response_alg } | `"HS256" \| "HS384" \| "HS512" \| "RS256" \| "RS384" \| "RS512" \| "ES256" \| "ES384" \| "ES512" \| "PS256" \| "PS384" \| "PS512" \| "Ed25519" \| "Ed25519ph" \| "Ed448" \| "Ed448ph" \| "EdDSA"` | `"RS256"` | The `id_token_signed_response_alg` parameter sent by the Client during Registration. |
 | [`id_token_ttl_seconds`](#authentication-strategies-apple-id_token_ttl_seconds){: #authentication-strategies-apple-id_token_ttl_seconds } | `nil \| pos_integer` |  | The number of seconds from `iat` that an ID Token will be considered valid. |
 | [`nonce`](#authentication-strategies-apple-nonce){: #authentication-strategies-apple-nonce } | `boolean \| (any, any -> any) \| module \| String.t` | `true` | A function for generating the session nonce, `true` to automatically generate it with `AshAuthentication.Strategy.Oidc.NonceGenerator`, or `false` to disable. |
+| [`private_key_path`](#authentication-strategies-apple-private_key_path){: #authentication-strategies-apple-private_key_path } | `(any, any -> any) \| module \| String.t` |  | The path to the private key file used for signing the JWT token. Required if `private_key` is not set. |
 
 
 

--- a/lib/ash_authentication/strategies/apple.ex
+++ b/lib/ash_authentication/strategies/apple.ex
@@ -16,7 +16,7 @@ defmodule AshAuthentication.Strategy.Apple do
     - `client_id`
     - `team_id`
     - `private_key_id`
-    - `private_key_path`
+    - `private_key_path` or `private_key`
     - `redirect_uri`
 
   ## More documentation:

--- a/lib/ash_authentication/strategies/apple/dsl.ex
+++ b/lib/ash_authentication/strategies/apple/dsl.ex
@@ -51,7 +51,7 @@ defmodule AshAuthentication.Strategy.Apple.Dsl do
         required: true
       ],
       private_key_path: [
-        type: {:or, [nil, secret_type]},
+        type: secret_type,
         doc:
           "The path to the private key file used for signing the JWT token. Required if `private_key` is not set.",
         required: false

--- a/lib/ash_authentication/strategies/apple/dsl.ex
+++ b/lib/ash_authentication/strategies/apple/dsl.ex
@@ -51,9 +51,10 @@ defmodule AshAuthentication.Strategy.Apple.Dsl do
         required: true
       ],
       private_key_path: [
-        type: secret_type,
-        doc: "The path to the private key file used for signing the JWT token.",
-        required: true
+        type: {:or, [nil, secret_type]},
+        doc:
+          "The path to the private key file used for signing the JWT token. Required if `private_key` is not set.",
+        required: false
       ]
     )
   end

--- a/lib/ash_authentication/strategies/apple/verifier.ex
+++ b/lib/ash_authentication/strategies/apple/verifier.ex
@@ -8,6 +8,7 @@ defmodule AshAuthentication.Strategy.Apple.Verifier do
   """
 
   alias AshAuthentication.Strategy.OAuth2
+  alias Spark.Error.DslError
   import AshAuthentication.Validations
 
   @doc false
@@ -16,9 +17,24 @@ defmodule AshAuthentication.Strategy.Apple.Verifier do
     with :ok <- validate_secret(strategy, :client_id),
          :ok <- validate_secret(strategy, :team_id),
          :ok <- validate_secret(strategy, :private_key_id),
-         :ok <- validate_secret(strategy, :private_key_path),
-         :ok <- validate_secret(strategy, :redirect_uri) do
+         :ok <- validate_secret(strategy, :redirect_uri),
+         :ok <- validate_private_key(strategy) do
       oauth2_strategy_warnings(strategy, dsl_state)
     end
+  end
+
+  defp validate_private_key(%{private_key: nil} = strategy),
+    do: validate_secret(strategy, :private_key_path)
+
+  defp validate_private_key(%{private_key_path: nil} = strategy),
+    do: validate_secret(strategy, :private_key)
+
+  defp validate_private_key(strategy) do
+    {:error,
+     DslError.exception(
+       path: [:authentication, :strategies, strategy.name],
+       message: "Either `private_key_path` or `private_key` must be configured, not both.",
+       module: strategy.resource
+     )}
   end
 end

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -136,8 +136,20 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
            add_secret_value(
              config,
              strategy,
+             :private_key,
+             strategy.assent_strategy != Assent.Strategy.Apple ||
+               (strategy.assent_strategy == Assent.Strategy.Apple &&
+                  !!strategy.private_key_path),
+             context
+           ),
+         {:ok, config} <-
+           add_secret_value(
+             config,
+             strategy,
              :private_key_path,
-             strategy.assent_strategy != Assent.Strategy.Apple,
+             strategy.assent_strategy != Assent.Strategy.Apple ||
+               (strategy.assent_strategy == Assent.Strategy.Apple &&
+                  !!strategy.private_key),
              context
            ),
          {:ok, config} <-

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -188,7 +188,7 @@ authentication do
       client_secret MyApp.Secrets
       redirect_uri MyApp.Secrets
       # auth0 also needs: base_url
-      # apple also needs: team_id, private_key_id, private_key_path
+      # apple also needs: team_id, private_key_id, private_key_path or private_key
       # oidc also needs: openid_configuration_uri
       identity_resource MyApp.Accounts.UserIdentity
     end
@@ -373,3 +373,4 @@ end
 ```
 
 For more guidance, see the "Customizing Authentication Actions" section in the getting started guide.
+


### PR DESCRIPTION
Getting the ball rolling on #1171 

Adding `private_key` in `oauth2/plug.ex` was necessary for the callback to complete, but I'm not sure about it.
Assent prefers `private_key_path` so that's the hangup we report in `verifier.ex` if neither is present.