### PR TITLE
fix: filter auto-generated get_by_<identity_field> lookup actions

### DIFF
--- a/lib/ash_authentication/strategies/custom/transformer.ex
+++ b/lib/ash_authentication/strategies/custom/transformer.ex
@@ -25,6 +25,13 @@ defmodule AshAuthentication.Strategy.Custom.Transformer do
   @impl true
   @spec before?(module) :: boolean
   def before?(Resource.Transformers.DefaultAccept), do: true
+  # Strategy transformers add auto-generated `get_by_<identity_field>` read
+  # actions (password, magic_link). Ash's GetByReadActions transformer is what
+  # turns their `get_by:` option into an actual filter — so it must run *after*
+  # the strategy transformers have added those actions, otherwise the actions
+  # stay unfiltered and `Ash.read_one` raises MultipleResults once more than
+  # one row exists.
+  def before?(Ash.Resource.Transformers.GetByReadActions), do: true
   def before?(_), do: false
 
   @doc false

--- a/test/ash_authentication/strategies/magic_link_test.exs
+++ b/test/ash_authentication/strategies/magic_link_test.exs
@@ -13,6 +13,31 @@ defmodule AshAuthentication.Strategy.MagicLinkTest do
 
   doctest MagicLink
 
+  describe "auto-generated lookup action (get_by_<identity_field>)" do
+    test "is scoped by a filter, even with multiple users present" do
+      # The strategy transformers auto-generate a `get_by_<identity_field>`
+      # read action with `get?: true`. Ash's GetByReadActions transformer must
+      # run after them to synthesize the filter from `get_by`; otherwise the
+      # action is unfiltered and `Ash.read_one` raises MultipleResults as soon
+      # as the table holds more than one row.
+      strategy = Info.strategy!(Example.User, :magic_link)
+
+      target = build_user()
+      _other = build_user()
+
+      identity_value = Map.fetch!(target, strategy.identity_field)
+
+      assert {:ok, found} =
+               Ash.read_one(
+                 Ash.Query.for_read(Example.User, strategy.lookup_action_name, %{
+                   strategy.identity_field => identity_value
+                 })
+               )
+
+      assert found.id == target.id
+    end
+  end
+
   describe "request_token_for/2" do
     test "it generates a sign in token" do
       user = build_user()


### PR DESCRIPTION
## Problem

The password and magic_link strategy transformers add an auto-generated `get_by_<identity_field>` read action with `get_by: [identity_field]` and `get?: true`. Ash's `Ash.Resource.Transformers.GetByReadActions` is what turns that `get_by` option into an actual `filter` on the action — but `AshAuthentication.Strategy.Custom.Transformer` declared no ordering relative to it. So `GetByReadActions` can run **before** the strategy transformers add their actions, and never synthesizes the filter.

The action then runs **unfiltered**, and because it is `get?: true` (read via `Ash.read_one`), it raises `Ash.Error.Invalid.MultipleResults` as soon as the resource's table holds more than one row — user lookup breaks in any real database. (It passes in single-row unit tests, which is why it can go unnoticed.)

Confirmed at runtime on `main` before the fix:

```
Example.User.get_by_username: get_by=[:username] filter=nil
```

## Fix

Declare `Custom.Transformer.before?(Ash.Resource.Transformers.GetByReadActions)` so the strategy transformers' `get_by` actions exist before the filter is synthesized. One line, at the root cause; fixes both the password and magic_link lookup actions at once (no per-strategy patching).

After the fix:

```
Example.User.get_by_username: get_by=[:username] filter=<username == arg(:username)>
```

## Test

Adds a regression test to `magic_link_test.exs`: with two users present, the auto-generated lookup action returns the correct single user rather than raising `MultipleResults`. Full suite green (716 tests + 22 doctests).