### PR TITLE
improvement: OAuth2/OIDC POST callback + form_post interstitial (Sign in with Apple)

### DIFF
--- a/documentation/topics/upgrading.md
+++ b/documentation/topics/upgrading.md
@@ -133,6 +133,22 @@ The `password` and `magic_link` strategies now support a `brute_force_strategy` 
 
 Defaults to a 5 minute window with 5 allowed failures; tune `audit_log_window` and `audit_log_max_failures` on each strategy if you need different thresholds.
 
+#### Sign in with Apple and other `response_mode=form_post` providers
+
+OAuth2/OIDC callbacks now accept **`POST` as well as `GET`**. This supports providers that use `response_mode=form_post` — most importantly **Sign in with Apple**, which returns the callback as a `POST` whenever `name` or `email` scope is requested.
+
+That callback is a *cross-site* `POST` from the provider, so the browser does not send the `SameSite=Lax` session cookie with it — which is why the stored `state`/`nonce`/PKCE verifier couldn't be read and sign-in failed. To handle this **without** weakening your session cookie to `SameSite=None`, the callback now renders a small **"signing you in…" interstitial** that immediately re-`POST`s the parameters *same-origin* (kept in the request body, never the URL), where the session cookie *is* sent and sign-in completes. The page fails closed if it can't recover the session, and is a no-op for providers that use a normal `GET` callback.
+
+**Using `ash_authentication_phoenix`:** the installer and upgrader generate an editable interstitial for you — a `signing_in.html.eex` template, an `AuthInterstitialHTML` renderer module, and the `:oauth2_interstitial_renderer` config — but only when your resources define an OAuth/OIDC strategy. It's created automatically when you add one via `mix ash_authentication_phoenix.add_strategy apple` (or `google`, `github`, `oidc`, …), and the upgrader adds it to existing OAuth apps. Edit the generated `signing_in.html.eex` to customise the copy or branding.
+
+**Hand-rolled routers / non-Phoenix apps:** no code change is required to *route* the callback (it already accepts both methods), and the built-in default interstitial renders with zero configuration. Keep your session cookie on the default `SameSite=Lax`. To customise the page, set:
+
+```elixir
+config :ash_authentication, :oauth2_interstitial_renderer, {MyApp.SomeModule, :render}
+```
+
+where the function takes the render assigns (`:action`, `:params`, `:reflected_param`) and returns the HTML.
+
 ### Other Improvements
 
 - **Auto signout in AshAuthentication.Phoenix** - Automatic sign-out is now supported in the Phoenix integration

--- a/documentation/topics/upgrading.md
+++ b/documentation/topics/upgrading.md
@@ -139,15 +139,34 @@ OAuth2/OIDC callbacks now accept **`POST` as well as `GET`**. This supports prov
 
 That callback is a *cross-site* `POST` from the provider, so the browser does not send the `SameSite=Lax` session cookie with it — which is why the stored `state`/`nonce`/PKCE verifier couldn't be read and sign-in failed. To handle this **without** weakening your session cookie to `SameSite=None`, the callback now renders a small **"signing you in…" interstitial** that immediately re-`POST`s the parameters *same-origin* (kept in the request body, never the URL), where the session cookie *is* sent and sign-in completes. The page fails closed if it can't recover the session, and is a no-op for providers that use a normal `GET` callback.
 
-**Using `ash_authentication_phoenix`:** the installer and upgrader generate an editable interstitial for you — a `signing_in.html.eex` template, an `AuthInterstitialHTML` renderer module, and the `:oauth2_interstitial_renderer` config — but only when your resources define an OAuth/OIDC strategy. It's created automatically when you add one via `mix ash_authentication_phoenix.add_strategy apple` (or `google`, `github`, `oidc`, …), and the upgrader adds it to existing OAuth apps. Edit the generated `signing_in.html.eex` to customise the copy or branding.
+Because the callback is a cross-site `POST`, Phoenix's `:protect_from_forgery` (which has no CSRF token to check) would otherwise reject it — so it must be skipped for that request (OAuth `state` is the CSRF defence). `ash_authentication_phoenix` provides a `:skip_csrf_for_oauth_callback` plug that skips CSRF **only** for `POST`s to callback paths; every other request (including all other auth POSTs) stays fully protected.
 
-**Hand-rolled routers / non-Phoenix apps:** no code change is required to *route* the callback (it already accepts both methods), and the built-in default interstitial renders with zero configuration. Keep your session cookie on the default `SameSite=Lax`. To customise the page, set:
+**Using `ash_authentication_phoenix`:** when your resources define an OAuth/OIDC strategy, the installer and upgrader do two things automatically:
 
-```elixir
-config :ash_authentication, :oauth2_interstitial_renderer, {MyApp.SomeModule, :render}
-```
+1. Generate an editable interstitial — a `signing_in.html.eex` template, an `AuthInterstitialHTML` renderer module, and the `:oauth2_interstitial_renderer` config. Edit `signing_in.html.eex` to customise copy/branding.
+2. Prepend `plug :skip_csrf_for_oauth_callback` to your `:browser` pipeline (before `:protect_from_forgery`).
 
-where the function takes the render assigns (`:action`, `:params`, `:reflected_param`) and returns the HTML.
+Both happen when you add a provider via `mix ash_authentication_phoenix.add_strategy apple` (or `google`, `github`, `oidc`, …), and the upgrader applies them to existing OAuth apps.
+
+**Hand-rolled routers / non-Phoenix apps:** no code change is required to *route* the callback (it already accepts both methods), and the built-in default interstitial renders with zero configuration. Keep your session cookie on the default `SameSite=Lax`, but:
+
+- Ensure the callback `POST` is exempt from CSRF. With `ash_authentication_phoenix`, add its plug before `:protect_from_forgery`:
+
+  ```elixir
+  pipeline :browser do
+    # ...
+    plug :skip_csrf_for_oauth_callback
+    plug :protect_from_forgery
+  end
+  ```
+
+- To customise the interstitial page, set:
+
+  ```elixir
+  config :ash_authentication, :oauth2_interstitial_renderer, {MyApp.SomeModule, :render}
+  ```
+
+  where the function takes the render assigns (`:action`, `:params`, `:reflected_param`) and returns the HTML.
 
 ### Other Improvements
 

--- a/lib/ash_authentication/plug/router.ex
+++ b/lib/ash_authentication/plug/router.ex
@@ -48,7 +48,7 @@ defmodule AshAuthentication.Plug.Router do
         end)
 
       for {path, method, config} <- routes do
-        match(path, to: Dispatcher, via: [method], init_opts: [config])
+        match(path, to: Dispatcher, via: List.wrap(method), init_opts: [config])
       end
 
       match(_, to: Dispatcher, init_opts: [unquote(return_to)])

--- a/lib/ash_authentication/strategies/oauth2/interstitial.html.eex
+++ b/lib/ash_authentication/strategies/oauth2/interstitial.html.eex
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<%!--
+  Default "signing you in…" interstitial for OAuth2/OIDC providers that return
+  the callback as a cross-site form_post POST (e.g. Apple). The browser does not
+  send the SameSite=Lax session cookie on the cross-site POST, so this page
+  re-POSTs the response parameters SAME-ORIGIN, where the session cookie is sent
+  and the callback can verify state and complete sign-in.
+
+  Parameters are kept in the POST body (never the URL) and are HTML-escaped. The
+  form auto-submits; a manual button is provided for no-JS environments.
+--%>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Signing you in…</title>
+  </head>
+  <body onload="document.forms[0].submit()">
+    <form method="post" action="<%= Plug.HTML.html_escape(@action) %>">
+      <%= for {key, value} <- @params do %>
+        <input type="hidden" name="<%= Plug.HTML.html_escape(to_string(key)) %>" value="<%= Plug.HTML.html_escape(to_string(value)) %>" />
+      <% end %>
+      <input type="hidden" name="<%= @reflected_param %>" value="1" />
+      <noscript>
+        <p>Signing you in…</p>
+        <button type="submit">Continue</button>
+      </noscript>
+    </form>
+    <p>Signing you in…</p>
+  </body>
+</html>

--- a/lib/ash_authentication/strategies/oauth2/interstitial.html.eex.license
+++ b/lib/ash_authentication/strategies/oauth2/interstitial.html.eex.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+
+SPDX-License-Identifier: MIT

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -111,7 +111,13 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
       conn: conn
     }
 
+    # Do NOT write the session on this response. Other plugs in the pipeline
+    # (e.g. flash) may have marked the session dirty; writing it here would send
+    # a fresh cookie that clobbers the real session in the browser, so the
+    # same-origin re-POST would arrive without it. `ignore: true` preserves the
+    # existing session cookie untouched.
     conn
+    |> configure_session(ignore: true)
     |> put_resp_content_type("text/html")
     |> send_resp(200, interstitial_html(assigns))
   end

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -72,12 +72,64 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
       store_authentication_result(conn, {:ok, user})
     else
       nil ->
-        store_authentication_result(conn, {:error, nil})
+        maybe_reflect_or_fail(conn, strategy)
 
       {:error, reason} ->
         store_authentication_result(conn, {:error, reason})
     end
   end
+
+  # The session holding `session_params` is absent. This is expected when a
+  # provider using `response_mode=form_post` (e.g. Apple with name/email scope)
+  # POSTs the callback cross-site: the browser withholds the `SameSite=Lax`
+  # session cookie on a cross-site POST. Render an interstitial page that
+  # same-origin re-POSTs the params so the follow-up request carries the
+  # session. On the (same-origin) re-POST `session_params` is present and the
+  # `with` above succeeds; if it is *still* absent we've already bounced once,
+  # so fail closed rather than loop.
+  defp maybe_reflect_or_fail(conn, strategy) do
+    if conn.method == "POST" and not reflected?(conn) do
+      render_interstitial(conn, strategy)
+    else
+      store_authentication_result(conn, {:error, nil})
+    end
+  end
+
+  @reflected_param "_ash_authentication_reflected"
+
+  defp reflected?(conn), do: Map.get(conn.params, @reflected_param) == "1"
+
+  defp render_interstitial(conn, strategy) do
+    params = Map.drop(conn.params, [@reflected_param, "glob"])
+
+    assigns = %{
+      action: conn.request_path,
+      params: params,
+      reflected_param: @reflected_param,
+      strategy: strategy,
+      conn: conn
+    }
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(200, interstitial_html(assigns))
+  end
+
+  defp interstitial_html(assigns) do
+    case Application.get_env(:ash_authentication, :oauth2_interstitial_renderer) do
+      {module, function} -> apply(module, function, [assigns])
+      _ -> render_default_interstitial(assigns)
+    end
+  end
+
+  require EEx
+
+  EEx.function_from_file(
+    :defp,
+    :render_default_interstitial,
+    Path.join(__DIR__, "interstitial.html.eex"),
+    [:assigns]
+  )
 
   defp action_opts(conn) do
     [actor: get_actor(conn), tenant: get_tenant(conn), context: get_context(conn) || %{}]

--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -99,6 +99,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
 
   defp reflected?(conn), do: Map.get(conn.params, @reflected_param) == "1"
 
+  # sobelow_skip ["XSS.SendResp"]
   defp render_interstitial(conn, strategy) do
     params = Map.drop(conn.params, [@reflected_param, "glob"])
 

--- a/lib/ash_authentication/strategies/oauth2/strategy.ex
+++ b/lib/ash_authentication/strategies/oauth2/strategy.ex
@@ -32,9 +32,11 @@ defimpl AshAuthentication.Strategy, for: AshAuthentication.Strategy.OAuth2 do
   def actions(%OAuth2{registration_enabled?: false}), do: [:sign_in]
 
   @doc false
-  @spec method_for_phase(OAuth2.t(), phase) :: Strategy.http_method()
+  @spec method_for_phase(OAuth2.t(), phase) :: Strategy.http_method() | [Strategy.http_method()]
   def method_for_phase(_, :request), do: :get
-  def method_for_phase(_, :callback), do: :get
+  # Accept POST as well as GET so providers using `response_mode=form_post`
+  # (e.g. Apple when name/email scope is requested) can reach the callback.
+  def method_for_phase(_, :callback), do: [:get, :post]
 
   @doc """
   Return a list of routes for use by the strategy.

--- a/lib/ash_authentication/strategy.ex
+++ b/lib/ash_authentication/strategy.ex
@@ -102,7 +102,7 @@ defprotocol AshAuthentication.Strategy do
       :get
 
   """
-  @spec method_for_phase(t, phase) :: http_method
+  @spec method_for_phase(t, phase) :: http_method | [http_method]
   def method_for_phase(t, phase)
 
   @doc """

--- a/test/ash_authentication/strategies/oauth2/plug_test.exs
+++ b/test/ash_authentication/strategies/oauth2/plug_test.exs
@@ -27,4 +27,63 @@ defmodule AshAuthentication.Strategy.OAuth2.PlugTest do
       assert session.state =~ ~r/.+/
     end
   end
+
+  describe "callback/2 with no session (cross-site form_post)" do
+    setup do
+      {:ok, strategy} = Info.strategy(Example.User, :oauth2)
+      {:ok, strategy: strategy}
+    end
+
+    test "a POST with no session renders an interstitial that re-POSTs same-origin", %{
+      strategy: strategy
+    } do
+      conn =
+        :post
+        |> conn("/user/oauth2/callback", %{"code" => "abc", "state" => "x<script>"})
+        |> SessionPipeline.call([])
+        |> Plug.callback(strategy)
+
+      assert conn.status == 200
+
+      assert {"content-type", "text/html" <> _} =
+               Enum.find(conn.resp_headers, &(elem(&1, 0) == "content-type"))
+
+      body = conn.resp_body
+      assert body =~ ~s(<form method="post" action="/user/oauth2/callback">)
+      assert body =~ ~s(name="code" value="abc")
+      # values are HTML-escaped
+      assert body =~ ~s(value="x&lt;script&gt;")
+      refute body =~ "x<script>"
+      # the loop guard marker is added
+      assert body =~ ~s(name="_ash_authentication_reflected" value="1")
+    end
+
+    test "an already-reflected POST with no session fails closed rather than looping", %{
+      strategy: strategy
+    } do
+      conn =
+        :post
+        |> conn("/user/oauth2/callback", %{
+          "code" => "abc",
+          "state" => "xyz",
+          "_ash_authentication_reflected" => "1"
+        })
+        |> SessionPipeline.call([])
+        |> Plug.callback(strategy)
+
+      refute conn.status == 200
+      assert conn.private[:authentication_result] == {:error, nil}
+    end
+
+    test "a GET with no session does not render an interstitial", %{strategy: strategy} do
+      conn =
+        :get
+        |> conn("/user/oauth2/callback", %{"code" => "abc"})
+        |> SessionPipeline.call([])
+        |> Plug.callback(strategy)
+
+      refute conn.status == 200
+      assert conn.private[:authentication_result] == {:error, nil}
+    end
+  end
 end

--- a/test/ash_authentication/strategies/oauth2/plug_test.exs
+++ b/test/ash_authentication/strategies/oauth2/plug_test.exs
@@ -56,6 +56,11 @@ defmodule AshAuthentication.Strategy.OAuth2.PlugTest do
       refute body =~ "x<script>"
       # the loop guard marker is added
       assert body =~ ~s(name="_ash_authentication_reflected" value="1")
+
+      # the interstitial must NOT rewrite the session cookie, or the fresh cookie
+      # would clobber the real session and the same-origin re-POST would arrive
+      # without it.
+      assert conn.private[:plug_session_info] == :ignore
     end
 
     test "an already-reflected POST with no session fails closed rather than looping", %{

--- a/test/ash_authentication/strategies/oauth2/strategy_test.exs
+++ b/test/ash_authentication/strategies/oauth2/strategy_test.exs
@@ -37,8 +37,8 @@ defmodule AshAuthentication.Strategy.OAuth2.StrategyTest do
       assert :get = Strategy.method_for_phase(%OAuth2{}, :request)
     end
 
-    test "it is get for the callback phase" do
-      assert :get = Strategy.method_for_phase(%OAuth2{}, :callback)
+    test "it accepts get and post for the callback phase" do
+      assert [:get, :post] = Strategy.method_for_phase(%OAuth2{}, :callback)
     end
   end
 


### PR DESCRIPTION
Draft — coordinated with the ash_authentication_phoenix PR (same branch name). Resolves #1181.

## What & why

Providers using `response_mode=form_post` (notably **Sign in with Apple**, whenever `name`/`email` scope is requested) return the OAuth callback as a **cross-site POST**. The browser withholds the `SameSite=Lax` session cookie on that POST, so the stored `state`/`nonce`/PKCE verifier can't be read and sign-in fails.

This makes the OAuth2/OIDC callback accept **GET and POST**, and when the session is absent it renders a small **"signing you in…" interstitial** that immediately re-POSTs the params **same-origin** (kept in the body, HTML-escaped), where the session cookie *is* sent and sign-in completes. No `SameSite=None` required.

The approach (and the security trade-offs considered — dedicated `None` cookie vs stateless vs this reflector) is written up on #1181; the reflector was validated end-to-end in a browser spike (Chrome), and it rides the fundamental *same-origin* cookie rule rather than the browser-divergent redirect-chain behaviour that ruled out a 302 trampoline.

## Changes
- `method_for_phase(_, :callback)` now returns `[:get, :post]` (spec widened to `http_method | [http_method]`; router uses `List.wrap`). Backward-compatible for single-atom impls.
- `OAuth2.Plug.callback/2`: session-absent → render interstitial (re-POST + `_ash_authentication_reflected` guard); already-reflected → **fail closed** (no loop); GET/session-present paths unchanged.
- Default `interstitial.html.eex` rendered from the plug (mirrors `MagicLink.Plug`), overridable via the `:oauth2_interstitial_renderer` app config.
- 5.0.0 upgrade-guide section.

## Notes
- Phoenix-side generation of an editable interstitial lives in the AAP PR.
- The `.heex`+layout render path is deliberately deferred (default EEx only).