### PR TITLE
fix: expired magic link raises Ash.Error.Unknown instead of calling failure/3 (#1190)

### DIFF
--- a/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
+++ b/lib/ash_authentication/strategies/remember_me/maybe_generate_token_preparation.ex
@@ -107,7 +107,7 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparation do
     end
   end
 
-  defp verify_result(query, _resource, _strategy, _context) do
-    {:ok, query}
+  defp verify_result(_query, records, _strategy, _context) do
+    {:ok, records}
   end
 end

--- a/test/ash_authentication/strategies/remember_me/maybe_generate_token_preparation_test.exs
+++ b/test/ash_authentication/strategies/remember_me/maybe_generate_token_preparation_test.exs
@@ -62,4 +62,18 @@ defmodule AshAuthentication.Strategy.RememberMe.MaybeGenerateTokenPreparationTes
                MaybeGenerateTokenPreparation.prepare(query, options, context)
     end
   end
+
+  describe "after_action hook" do
+    test "passes an empty result list through untouched" do
+      query =
+        UserWithRememberMe
+        |> Ash.Query.new()
+        |> Ash.Query.set_argument(:remember_me, true)
+
+      assert %Ash.Query{after_action: [hook]} =
+               MaybeGenerateTokenPreparation.prepare(query, [], %{})
+
+      assert {:ok, []} = hook.(query, [])
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1190.

## Problem

`RememberMe.MaybeGenerateTokenPreparation`'s `after_action` hook has the signature `(query, records)`, but its catch-all clause bound the records to `_resource` and returned the **query** instead:

```elixir
defp verify_result(query, _resource, _strategy, _context) do
  {:ok, query}
end
```

When a magic-link sign-in fails (expired/invalid token), `MagicLink.SignInPreparation` applies a `false` filter and produces `{:ok, []}`. That empty list hit the catch-all, which handed the `Ash.Query` struct back to Ash as if it were the record list. Ash then tried to run calculations over it and raised:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Ash.Query (a struct)
```

surfacing as `Ash.Error.Unknown` and a 500. `MagicLink.Actions.sign_in/3` never got to turn `{:ok, []}` into `AuthenticationFailed`, so the controller's `failure/3` callback never ran — clicking an expired magic link was a dead end instead of the intended redirect back to sign-in.

Password sign-in is unaffected: `Password.SignInPreparation` returns `{:error, AuthenticationFailed}` on the empty case *before* this hook runs. Magic link is the only built-in strategy that passes a plain `{:ok, []}` through to the remember-me hook.

## Fix

Return the records untouched so the empty result flows through to `Actions.sign_in/3` and becomes `AuthenticationFailed`:

```elixir
defp verify_result(_query, records, _strategy, _context) do
  {:ok, records}
end
```

Plus a regression test that invokes the registered after-action hook with an empty result and asserts it passes `{:ok, []}` through.
