### PR TITLE
fix: remove a duplicate call in the installer

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -185,6 +185,7 @@ defmodule MyApp.Accounts.User do
       enabled? true
       token_resource MyApp.Accounts.Token
       store_all_tokens? true
+      require_token_presence_for_authentication? true
       signing_secret fn _, _ ->
         # This is a secret key used to sign tokens. See the note below on secrets management
         Application.fetch_env(:my_app, :token_signing_secret)

--- a/lib/mix/tasks/ash_authentication.install.ex
+++ b/lib/mix/tasks/ash_authentication.install.ex
@@ -245,11 +245,6 @@ if Code.ensure_loaded?(Igniter) do
       )
       |> Spark.Igniter.set_option(
         user_resource,
-        [:authentication, :tokens, :token_resource],
-        token_resource
-      )
-      |> Spark.Igniter.set_option(
-        user_resource,
         [:authentication, :tokens, :signing_secret],
         secrets_module
       )


### PR DESCRIPTION
Two nothing burgers:

- Noticed that there is a duplicate call to set `[:authentication, :tokens, :token_resource]` in the installer.

- Noticed that in manual installation documentation `require_token_presence_for_authentication? true` is missing even though Igniter does set it and it is documented to be required by `LogOutEverywhere` add-on.