### PR TITLE
fix: don't delete the session when a resource requires a tenant

### DIFF
--- a/lib/ash_authentication/plug/helpers.ex
+++ b/lib/ash_authentication/plug/helpers.ex
@@ -216,12 +216,13 @@ defmodule AshAuthentication.Plug.Helpers do
         authenticate_resource_from_session(resource, session, otp_app, opts),
         resource,
         options,
-        session
+        session,
+        opts
       )
     end)
   end
 
-  defp handle_session_auth_result(conn, {:ok, user}, _resource, options, session) do
+  defp handle_session_auth_result(conn, {:ok, user}, _resource, options, session, _opts) do
     current_subject_name = current_subject_name(options.subject_name)
 
     # Restore authentication metadata from the session onto the user
@@ -230,7 +231,7 @@ defmodule AshAuthentication.Plug.Helpers do
     Conn.assign(conn, current_subject_name, user)
   end
 
-  defp handle_session_auth_result(conn, :error, resource, options, _session) do
+  defp handle_session_auth_result(conn, :error, resource, options, _session, opts) do
     current_subject_name = current_subject_name(options.subject_name)
 
     require_token? =
@@ -239,9 +240,22 @@ defmodule AshAuthentication.Plug.Helpers do
     session_key =
       if require_token?, do: session_key(options.subject_name), else: options.subject_name
 
-    conn
-    |> Conn.assign(current_subject_name, nil)
-    |> Conn.delete_session(session_key)
+    conn = Conn.assign(conn, current_subject_name, nil)
+
+    if tenant_required?(resource, opts) do
+      # The lookup was rejected before it could reach the data layer because this
+      # request has no tenant, so we know nothing about whether the session is
+      # valid and must leave it alone rather than signing the user out.
+      conn
+    else
+      Conn.delete_session(conn, session_key)
+    end
+  end
+
+  defp tenant_required?(resource, opts) do
+    is_nil(Keyword.get(opts, :tenant)) and
+      not is_nil(Resource.Info.multitenancy_strategy(resource)) and
+      not Resource.Info.multitenancy_global?(resource)
   end
 
   defp restore_metadata_from_session(user, subject_name, session) do

--- a/test/ash_authentication/plug/helpers_test.exs
+++ b/test/ash_authentication/plug/helpers_test.exs
@@ -160,6 +160,33 @@ defmodule AshAuthentication.Plug.HelpersTest do
       refute conn.assigns.current_user_with_token_required
     end
 
+    test "when the subject can't be found it removes the session", %{conn: conn} do
+      conn =
+        conn
+        |> Conn.put_session("user", "jti:user?id=#{Ash.UUID.generate()}")
+        |> Helpers.retrieve_from_session(:ash_authentication)
+
+      refute conn.assigns.current_user
+      refute conn.private.plug_session["user"]
+    end
+
+    test "when a resource requires a tenant and the request has none it keeps the session", %{
+      conn: conn
+    } do
+      # Without a tenant the query is rejected by Ash before it reaches the data
+      # layer, so we have learned nothing about whether the session is valid and
+      # must not discard it.
+      session_value = "jti:multi_tenant_user_with_web_authn?id=#{Ash.UUID.generate()}"
+
+      conn =
+        conn
+        |> Conn.put_session("multi_tenant_user_with_web_authn", session_value)
+        |> Helpers.retrieve_from_session(:ash_authentication)
+
+      refute conn.assigns.current_multi_tenant_user_with_web_authn
+      assert conn.private.plug_session["multi_tenant_user_with_web_authn"] == session_value
+    end
+
     test "with opts", %{conn: conn} do
       # without token
       user = build_user()


### PR DESCRIPTION
### The failure mode

`Plug.Helpers.retrieve_from_session/3` iterates every authenticated resource for the otp_app and deletes the session key of each one it can't resolve a user for. For a multitenant resource with `global? false`, a request that carries no tenant fails with `Ash.Error.Invalid.TenantRequired` — the query is rejected by `Ash.Actions.Read.validate_multitenancy/1` before it reaches the data layer — and the perfectly good session is deleted anyway.

### Who it affects

Any app with a tenant-scoped authenticated resource plus a pipeline that doesn't set an Ash tenant: an admin/staff area, a webhook endpoint, a health check, or simply a second authenticated resource whose pipeline is tenant-less. Users of the multitenant resource are silently signed out by requests to those routes.

Note that `retrieve_from_session/3` reads the tenant from `Ash.PlugHelpers.get_tenant(conn)` only, so this bites whenever the plug pipeline hasn't set one — `assign_new_resources/4` has a `session["tenant"]` fallback, but the plug path does not.

### Reproduction

Two authenticated resources, one of them multitenant and not `global?`; a request through a pipeline that sets no tenant. The multitenant resource's session key is gone afterwards even though the subject is untouched. The added test uses the existing `Example.MultiTenantUserWithWebAuthn` fixture, which is already `multitenancy do strategy :context end`.

### The fix

Only delete the session key when the lookup was actually able to run. If the resource declares multitenancy, isn't `global?`, and this request has no tenant, the failure says nothing about the session, so leave it alone. Genuinely absent or unresolvable subjects are still cleared, as covered by the second added test.
