### PR TITLE
fix: return error tuple from Jwt.peek/1 on malformed tokens

### DIFF
--- a/lib/ash_authentication/jwt.ex
+++ b/lib/ash_authentication/jwt.ex
@@ -238,7 +238,11 @@ defmodule AshAuthentication.Jwt do
   Given a token, read it's claims without validating.
   """
   @spec peek(token) :: {:ok, claims} | {:error, any}
-  def peek(token), do: Joken.peek_claims(token)
+  def peek(token) do
+    Joken.peek_claims(token)
+  rescue
+    error -> {:error, error}
+  end
 
   @doc """
   Given a token, verify it's signature and validate it's claims.

--- a/test/ash_authentication/jwt_test.exs
+++ b/test/ash_authentication/jwt_test.exs
@@ -96,5 +96,9 @@ defmodule AshAuthentication.JwtTest do
 
       assert :error = Jwt.verify(token, :ash_authentication)
     end
+
+    test "it is unsuccessful when the token is malformed" do
+      assert :error = Jwt.verify("aaaa.bbbb.cccc", :ash_authentication)
+    end
   end
 end


### PR DESCRIPTION
Fixes #1199.

## Problem

`AshAuthentication.Jwt.peek/1` is spec'd as `{:ok, claims} | {:error, any}`, but it delegates straight to `Joken.peek_claims/1`, which *raises* for tokens whose segments do not base64/JSON decode. Every caller uses it in a `with {:ok, _} <- peek(token)` and expects the error tuple, so the raise escapes past the `else` clause. Through `retrieve_from_bearer/3 -> Jwt.verify/3 -> token_to_resource/2` this turns a malformed bearer token into an unhandled 500:

```
** (ErlangError) Erlang error: {:invalid_byte, 200}: invalid byte 16#C8 at byte position 0
    (joken 2.6.2) lib/joken.ex:156: Joken.peek_claims/1
    (ash_authentication) lib/ash_authentication/jwt.ex: AshAuthentication.Jwt.token_to_resource/2
```

`token_to_resource/2` already documents that it does not validate the token, so a malformed token should simply fail the lookup rather than crash the request.

## Fix

Wrap `Joken.peek_claims/1` in a rescue so `peek/1` honours its own `{:ok, _} | {:error, _}` contract. This fixes `token_to_resource/2` and every other `Jwt.peek/1` caller (revoke/store/is_revoked changes) at a single point, so `verify/3` returns `:error` and the plug treats the request as unauthenticated instead of raising.
