### PR TITLE
improvement: discover token and audit log resources via `ash_domains`

### DIFF
--- a/lib/ash_authentication.ex
+++ b/lib/ash_authentication.ex
@@ -194,17 +194,26 @@ defmodule AshAuthentication do
   Returns a list of resource modules.
   """
   @spec authenticated_resources(atom | [atom]) :: [Resource.t()]
-  def authenticated_resources(otp_app) do
+  def authenticated_resources(otp_app),
+    do: resources_with_extension(otp_app, AshAuthentication)
+
+  @doc """
+  Find all resources using a given extension for one or more OTP applications.
+
+  Resources are located by walking the domains configured in each application's
+  `:ash_domains` environment key, meaning that only resources registered with a
+  domain can be found.
+
+  Returns a list of resource modules.
+  """
+  @spec resources_with_extension(atom | [atom], module) :: [Resource.t()]
+  def resources_with_extension(otp_app, extension) do
     otp_app
     |> List.wrap()
-    |> Enum.flat_map(fn otp_app ->
-      otp_app
-      |> Application.get_env(:ash_domains, [])
-      |> Stream.flat_map(&Domain.Info.resources(&1))
-      |> Stream.uniq()
-      |> Stream.filter(&(AshAuthentication in Spark.extensions(&1)))
-      |> Enum.to_list()
-    end)
+    |> Stream.flat_map(&Ash.Info.domains/1)
+    |> Stream.flat_map(&Domain.Info.resources/1)
+    |> Stream.uniq()
+    |> Enum.filter(&(extension in Spark.extensions(&1)))
   end
 
   @doc """

--- a/lib/ash_authentication/audit_log_resource/batcher.ex
+++ b/lib/ash_authentication/audit_log_resource/batcher.ex
@@ -57,8 +57,7 @@ defmodule AshAuthentication.AuditLogResource.Batcher do
 
     audit_configs =
       otp_app
-      |> Spark.sparks(Ash.Resource)
-      |> Stream.filter(&(AuditLogResource in Spark.extensions(&1)))
+      |> AshAuthentication.resources_with_extension(AuditLogResource)
       |> Enum.reduce(%{}, fn resource, configs ->
         Map.put(configs, resource, %{
           timeout: Info.audit_log_write_batching_timeout!(resource),

--- a/lib/ash_authentication/audit_log_resource/expunger.ex
+++ b/lib/ash_authentication/audit_log_resource/expunger.ex
@@ -38,8 +38,7 @@ defmodule AshAuthentication.AuditLogResource.Expunger do
   def init(opts) do
     opts
     |> Keyword.fetch!(:otp_app)
-    |> Spark.sparks(Ash.Resource)
-    |> Stream.filter(&(AuditLogResource in Spark.extensions(&1)))
+    |> AshAuthentication.resources_with_extension(AuditLogResource)
     |> Enum.reduce([], fn resource, configs ->
       with {:ok, lifetime_days} when is_integer(lifetime_days) and lifetime_days > 0 <-
              Info.audit_log_log_lifetime(resource),

--- a/lib/ash_authentication/token_resource/expunger.ex
+++ b/lib/ash_authentication/token_resource/expunger.ex
@@ -40,8 +40,7 @@ defmodule AshAuthentication.TokenResource.Expunger do
 
     resource_states =
       otp_app
-      |> Spark.sparks(Ash.Resource)
-      |> Stream.filter(&(TokenResource in Spark.extensions(&1)))
+      |> AshAuthentication.resources_with_extension(TokenResource)
       |> Enum.reduce(%{}, fn resource, resources ->
         state =
           resources

--- a/test/ash_authentication/token_resource/expunger_test.exs
+++ b/test/ash_authentication/token_resource/expunger_test.exs
@@ -15,6 +15,24 @@ defmodule AshAuthentication.TokenResource.ExpungerTest do
       assert %{Example.Token => %{timer: timer, interval: interval}} = resource_states
       assert timer
       assert is_integer(interval) and interval > 0
+
+      for resource <- [Example.TokenWithCustomCreateTimestamp, ExampleMultiTenant.Token] do
+        assert is_map_key(resource_states, resource)
+      end
+    end
+
+    test "it only finds token resources registered with the configured domains" do
+      configured_domains = Application.get_env(:ash_authentication, :ash_domains, [])
+
+      on_exit(fn ->
+        Application.put_env(:ash_authentication, :ash_domains, configured_domains)
+      end)
+
+      Application.put_env(:ash_authentication, :ash_domains, [ExampleMultiTenant])
+
+      assert {:ok, %{resources: resource_states}} = Expunger.init(otp_app: :ash_authentication)
+
+      assert Map.keys(resource_states) == [ExampleMultiTenant.Token]
     end
   end
 


### PR DESCRIPTION
Fixes #1197

## Failure mode

Three of the four processes started by `AshAuthentication.Supervisor` discovered their resources with `Spark.sparks/2`:

```elixir
otp_app
|> Spark.sparks(Ash.Resource)
|> Stream.filter(&(TokenResource in Spark.extensions(&1)))
```

`Spark.sparks/2` reads `:application.get_key(otp_app, :modules)` and calls `Spark.Dsl.is?/2` on every one of them, which in turn calls `Code.ensure_loaded/1`. In interactive mode (`mix test`, `mix run`, `iex -S mix`) modules are loaded lazily, so this reads every beam file in the application from disk, serialised through the code server.

Because the scan runs inside a supervisor child's `init/1`, it blocks application start.

## Measured impact

From the reporter (2,008 modules, ~170MB of beams):

> In our app (2,008 modules, ~170MB of beams, large Ash resources compile to 1.6-2.4MB each) this adds ~17 seconds to every application boot: every `mix test` invocation, every dev server restart.
>
> With the supervisor disabled in the test env, boot went from 19.7s → 2.5s, and a single-file `mix test` from 21.1s → 3.3s end-to-end. (Parallelizing the loads doesn't help; the code server serializes them regardless.)

## What changed

`AshAuthentication.authenticated_resources/1` already resolved resources by walking the domains configured in the application's `:ash_domains` environment key, rather than scanning modules. That body is generalised into a new public `AshAuthentication.resources_with_extension/2`, and the three supervised processes now use it:

- `AshAuthentication.TokenResource.Expunger`
- `AshAuthentication.AuditLogResource.Expunger`
- `AshAuthentication.AuditLogResource.Batcher`

`authenticated_resources/1` becomes `resources_with_extension(otp_app, AshAuthentication)`, so there is one discovery path rather than two. Only the configured domain modules and the resources they register get loaded — a handful of modules instead of the whole application.

## Behaviour changes

There are two, both worth stating up front.

### Resources outside configured domains are no longer discovered

Token and audit log resources which are not registered with a domain listed in `:ash_domains` will not be expunged or batched.

- Ash already emits a compile-time warning for any resource that is not present in a known `Ash.Domain`, so this configuration is already discouraged.
- The escape hatch is a domain with `allow_unregistered? true`, whose resources `Ash.Domain.Info.resources/1` does not return. An application using that for its token or audit log resource would silently lose expunging.
- Authenticated (user) resources have always been located this way, so this makes discovery consistent across the library rather than introducing a new requirement.

### `authenticated_resources/1` now deduplicates across OTP applications

`Stream.uniq` moved from inside the per-application pipeline to across all of them. The old code was:

```elixir
|> List.wrap()
|> Enum.flat_map(fn otp_app ->
  otp_app
  |> Application.get_env(:ash_domains, [])
  |> Stream.flat_map(&Domain.Info.resources(&1))
  |> Stream.uniq()          # <- per application only
  ...
end)                        # <- outer concat does no deduplication
```

So the list form — `authenticated_resources([:app_a, :app_b])`, which the `@spec` has always permitted — returned a resource once per application that reached it. Two applications configuring the same domain, or configuring different domains that both register the same resource, yielded duplicates. The single-atom form deduplicated correctly then and still does.

This is a fix rather than a regression: the function is documented as returning "a list of resource modules", and duplicates only caused redundant work in callers such as `load_subjects/3` and `resource_for_subject_name/2`. It is still a change in observable output for the list form, so it is called out here rather than left to be found later. Every caller inside this library passes a single atom, so nothing internal changes.

## Testing

Postgres was unavailable for part of the earlier round of testing on this branch; everything below was re-run after the rebase against a stable database.

`mix check --no-retry` on the rebased branch: **all tools pass except `ex_unit`**, which reports 743/751 with 8 failures. Tools run: compiler, credo (strict), dialyzer, doctor, ex_doc, formatter, generate_migrations, hex_audit, reuse, sobelow, spark_cheat_sheets, spark_formatter, unused_deps.

Those 8 failures are all in `Mix.Tasks.AshAuthentication.UpgradeTest` and are pre-existing igniter codegen drift, unrelated to this change. Confirmed by running the full suite at seed 0 on a clean checkout of `main` at the rebase point (`7bc188b`), which fails the same 8 and passes 742/750 — the one-test difference being the test added here.

Three runs against a stable database now agree exactly:

| run | result | failures |
| --- | --- | --- |
| clean `main` @ `7bc188b`, `mix test --seed 0` | 742/750 | same 8 `UpgradeTest` |
| this branch, `mix test --seed 0` | 743/751 | same 8 `UpgradeTest` |
| this branch, `mix check --no-retry` | 743/751 | same 8 `UpgradeTest` |

An earlier `mix check` run on the pre-rebase branch reported 14 failures. It does not reproduce, and the extra 6 cannot be identified — that run's captured output was truncated to its tail, which shows only failures 12–14, all `UpgradeTest`. The database on this machine failed outright a few minutes after that run, so database instability is the most likely explanation, but that is inference rather than something confirmed.

`AshAuthentication.TokenResource.ExpungerTest` gains coverage for the new discovery path:

- `init/1` finds every token resource registered across the configured domains (`Example.Token`, `Example.TokenWithCustomCreateTimestamp`, `ExampleMultiTenant.Token`).
- With `:ash_domains` narrowed to `[ExampleMultiTenant]`, `init/1` finds only `ExampleMultiTenant.Token` — asserting discovery is scoped to configured domains rather than to every module in the application.