### PR TITLE
fix: don't clobber a strategy-supplied http_adapter

### DIFF
--- a/lib/ash_authentication/strategies/oauth2/plug.ex
+++ b/lib/ash_authentication/strategies/oauth2/plug.ex
@@ -392,6 +392,6 @@ defmodule AshAuthentication.Strategy.OAuth2.Plug do
         {Finch, supervisor: AshAuthentication.Finch}
       )
 
-    {:ok, Map.put(config, :http_adapter, http_adapter)}
+    {:ok, Map.put_new(config, :http_adapter, http_adapter)}
   end
 end


### PR DESCRIPTION
## Problem

`add_http_adapter/1` in `AshAuthentication.Strategy.OAuth2.Plug` unconditionally `Map.put`s the application-wide `:ash_authentication, :http_adapter` default over `config[:http_adapter]`, even when something earlier in the config-building pipeline already set it — e.g. a custom `Assent.Strategy`'s own `default_config/1`, or a future DSL-level `http_adapter` option (see #1192).

```elixir
defp add_http_adapter(config) do
  http_adapter =
    Application.get_env(:ash_authentication, :http_adapter, {Finch, supervisor: AshAuthentication.Finch})

  {:ok, Map.put(config, :http_adapter, http_adapter)}
end
```

## Fix

`Map.put_new` instead of `Map.put` — keeps a pre-set `:http_adapter` when present, falls back to the application default exactly as before otherwise. No behavior change for the common case where nothing sets it.

## Motivation

Raised as a follow-up in the #1192 discussion:

> One thing your PR does expose that's worth fixing separately: `add_http_adapter/1` uses `Map.put`, so it clobbers an `http_adapter` that a custom Assent strategy sets in its own `default_config/1`. Anyone needing genuinely transport-level treatment — client certs, a proxy, per-provider TLS — is blocked by that one line, and `Map.put_new` would unblock them without any new DSL. If you'd like to send that instead I'd take it.

This is that PR, sent separately per that suggestion.

## Test plan

- [x] Full existing test suite passes (758 tests, 0 failures) on a fresh checkout against upstream `main`.
- [x] Also validated against a real downstream consumer (a Phoenix app with a custom EdLink `Assent.Strategy`): pointed its `mix.exs` at this branch, ran its full feature and unit test suites — no regressions.
- No new test added: `:http_adapter` isn't yet a settable DSL field on `main` (that's #1192's scope), so there's currently no code path that pre-populates `config[:http_adapter]` for a test to observe the `Map.put`-vs-`Map.put_new` difference against. Happy to add one if you'd like it structured a particular way — e.g. a unit test directly on `config_for/2`'s output, or something else.

Marked as draft since it's a small, low-risk follow-up — happy to have it reviewed whenever convenient, independent of #1192's fate.