### PR TITLE
fix: validate the `subject` attribute in audit log write actions

### DIFF
--- a/lib/ash_authentication/audit_log_resource/transformer.ex
+++ b/lib/ash_authentication/audit_log_resource/transformer.ex
@@ -191,7 +191,7 @@ defmodule AshAuthentication.AuditLogResource.Transformer do
 
         fields ->
           with {:ok, id} <- Info.audit_log_attributes_id(dsl),
-               {:ok, subject} <- Info.audit_log_attributes_id(dsl),
+               {:ok, subject} <- Info.audit_log_attributes_subject(dsl),
                {:ok, strategy} <- Info.audit_log_attributes_strategy(dsl),
                {:ok, audit_log} <- Info.audit_log_attributes_audit_log(dsl),
                {:ok, logged_at} <- Info.audit_log_attributes_logged_at(dsl),

--- a/test/ash_authentication/audit_log_resource/transformer_test.exs
+++ b/test/ash_authentication/audit_log_resource/transformer_test.exs
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.AuditLogResource.TransformerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Ash.Resource.Info
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  describe "validate_write_action/2" do
+    test "a write action which doesn't accept the subject attribute fails to compile" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule AuditLogWithoutSubject do
+            @moduledoc false
+            use Ash.Resource,
+              data_layer: Ash.DataLayer.Ets,
+              domain: AshAuthentication.AuditLogResource.TransformerTest.Domain,
+              extensions: [AshAuthentication.AuditLogResource]
+
+            actions do
+              defaults [:read]
+
+              create :log_activity do
+                accept [
+                  :id,
+                  :strategy,
+                  :audit_log,
+                  :logged_at,
+                  :action_name,
+                  :status,
+                  :extra_data,
+                  :resource
+                ]
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "Missing:"
+      assert error.message =~ ":subject"
+    end
+
+    test "a write action which accepts all the required attributes compiles" do
+      defmodule AuditLogWithSubject do
+        @moduledoc false
+        use Ash.Resource,
+          data_layer: Ash.DataLayer.Ets,
+          domain: AshAuthentication.AuditLogResource.TransformerTest.Domain,
+          extensions: [AshAuthentication.AuditLogResource]
+
+        actions do
+          defaults [:read]
+
+          create :log_activity do
+            accept [
+              :id,
+              :subject,
+              :strategy,
+              :audit_log,
+              :logged_at,
+              :action_name,
+              :status,
+              :extra_data,
+              :resource
+            ]
+          end
+        end
+      end
+
+      assert Info.action(AuditLogWithSubject, :log_activity)
+    end
+  end
+end


### PR DESCRIPTION
Backport of the `subject` binding fix already on `main` (`800caa0`), bringing 4.x into line.

## The typo

`AuditLogResource.Transformer.validate_write_action/2` has two consecutive `with` bindings that both call `Info.audit_log_attributes_id/1`:

```elixir
with {:ok, id} <- Info.audit_log_attributes_id(dsl),
     {:ok, subject} <- Info.audit_log_attributes_id(dsl),
```

So `subject` is bound to the *id* attribute name. The `expected` MapSet contains the id twice and never the subject attribute, `MapSet.subset?/2` passes for a custom write action whose `accept` list omits `:subject`, and the `Missing:` error can never name it.

## Runtime consequence

`Auditor.after_transaction/4` always builds create params with a hardcoded `subject:` key. Against an action that does not accept it, that produces `Ash.Error.Invalid.NoSuchInput` and an invalid changeset. `allow_nil?: true` on the attribute is irrelevant — the failure is on the input key, before any null check. Batching is filtered on `changeset.valid?` before enqueueing, so the entry never reaches the batcher and no other pending entries are affected.

Net effect: an audit-log resource with such a write action compiles clean and then **drops every audit write at runtime**, successes and failures alike, with an error-level log per event. Verified empirically on 4.14.2.

Affected configuration: any audit log resource that replaces the generated write action with one of its own carrying an explicit `accept` list that omits the subject attribute. An operator would have observed an empty audit log despite authentication activity.

## Relationship to `main`

`main` fixed this in `800caa0`, where the binding reads `Info.audit_log_attributes_subject(dsl)`. The two lines have otherwise diverged — `main` renamed the function to `validate_accepted_fields/2` and added `identity` and `client_ip` attributes that do not exist on 4.x. Neither is ported here. On `stable-4.0` this is a one-word change and nothing else.

## Test

`stable-4.0` had no `test/ash_authentication/audit_log_resource/transformer_test.exs`; `main`'s version covers `log_lifetime` and generated actions, not accept-list validation, so this adds a new file covering the fixed behaviour:

- an audit log resource whose `:log_activity` write action accepts every required attribute *except* `:subject` fails to compile, raising `Spark.Error.DslError` whose message contains `Missing:` and names `:subject`
- a positive control: the same resource with `:subject` in the `accept` list compiles

Against the unfixed transformer the first test fails with `Expected exception Spark.Error.DslError but nothing was raised` — the resource compiles clean, which is the bug. With the fix, the raised message is `Missing: [:subject]`.

## Checks

`mix check --no-retry` is clean apart from two items unrelated to this change:

- `ex_unit`: 3 pre-existing failures in `test/mix/tasks/ash_authentication.upgrade_test.exs` (igniter `user_identity.ex` generation), confirmed identical on unmodified `stable-4.0`
- `reuse`: environmentally broken on the machine used here (the pipx-cached copy crashes at import under Python 3.14 with `NoEncodingModuleError` before reading any file). Verified separately with `pipx run --spec 'reuse[charset-normalizer]' reuse lint -q`, which exits 0.