### PR TITLE
fix(audit_log): make `include_strategies` filter the logged actions

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
+++ b/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
@@ -76,8 +76,8 @@ end
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`audit_log_resource`](#authentication-add_ons-audit_log-audit_log_resource){: #authentication-add_ons-audit_log-audit_log_resource .spark-required} | `module` |  | The name of the Audit Log resource. |
-| [`include_strategies`](#authentication-add_ons-audit_log-include_strategies){: #authentication-add_ons-audit_log-include_strategies } | `nil` | `[:*]` | Explicitly allow events from the named strategies. |
-| [`include_actions`](#authentication-add_ons-audit_log-include_actions){: #authentication-add_ons-audit_log-include_actions } | `nil` | `[:*]` | Explicitly allow events from the named actions. |
+| [`include_strategies`](#authentication-add_ons-audit_log-include_strategies){: #authentication-add_ons-audit_log-include_strategies } | `atom \| list(atom)` | `[:*]` | Explicitly allow events from the named strategies. |
+| [`include_actions`](#authentication-add_ons-audit_log-include_actions){: #authentication-add_ons-audit_log-include_actions } | `atom \| list(atom)` | `[:*]` | Explicitly allow events from the named actions. |
 | [`exclude_strategies`](#authentication-add_ons-audit_log-exclude_strategies){: #authentication-add_ons-audit_log-exclude_strategies } | `atom \| list(atom)` | `[]` | Explicitly ignore events from the named strategies. |
 | [`exclude_actions`](#authentication-add_ons-audit_log-exclude_actions){: #authentication-add_ons-audit_log-exclude_actions } | `atom \| list(atom)` | `[]` | Explicitly ignore events from the named actions. |
 | [`include_fields`](#authentication-add_ons-audit_log-include_fields){: #authentication-add_ons-audit_log-include_fields } | `atom \| list(atom)` | `[]` | Explicitly include named attributes and arguments in the audit log regardless of their sensitivity setting. |

--- a/lib/ash_authentication/add_ons/audit_log/dsl.ex
+++ b/lib/ash_authentication/add_ons/audit_log/dsl.ex
@@ -50,10 +50,12 @@ defmodule AshAuthentication.AddOn.AuditLog.Dsl do
           required: true
         ],
         include_strategies: [
+          type: {:wrap_list, :atom},
           doc: "Explicitly allow events from the named strategies.",
           default: [:*]
         ],
         include_actions: [
+          type: {:wrap_list, :atom},
           doc: "Explicitly allow events from the named actions.",
           default: [:*]
         ],

--- a/lib/ash_authentication/add_ons/audit_log/transformer.ex
+++ b/lib/ash_authentication/add_ons/audit_log/transformer.ex
@@ -7,6 +7,8 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
   use Spark.Dsl.Transformer
   alias Spark.Dsl.Transformer
 
+  @no_strategy :audit_log
+
   @doc false
   @impl true
   def after?(AshAuthentication.Strategy.Custom.Transformer), do: true
@@ -58,6 +60,8 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
       dsl
       |> AshAuthentication.Info.list_strategies()
       |> Enum.map(& &1.name)
+      |> Enum.concat([@no_strategy])
+      |> Enum.uniq()
 
     {:ok, %{strategy | include_strategies: strategy_names}}
   end
@@ -79,13 +83,12 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
     logged_actions =
       strategy.include_actions
       |> Stream.map(fn action_name ->
-        # For actions that belong to a strategy, use the strategy name
-        # For actions that don't belong to any strategy, use :audit_log as the strategy
         case AshAuthentication.Info.strategy_for_action(dsl, action_name) do
           {:ok, action_strategy} -> {action_name, action_strategy.name}
-          :error -> {action_name, :audit_log}
+          :error -> {action_name, @no_strategy}
         end
       end)
+      |> Stream.filter(&(elem(&1, 1) in strategy.include_strategies))
       |> Stream.reject(&(elem(&1, 0) in strategy.exclude_actions))
       |> Stream.reject(&(elem(&1, 1) in strategy.exclude_strategies))
       |> Enum.to_list()

--- a/lib/ash_authentication/add_ons/audit_log/verifier.ex
+++ b/lib/ash_authentication/add_ons/audit_log/verifier.ex
@@ -9,6 +9,11 @@ defmodule AshAuthentication.AddOn.AuditLog.Verifier do
   use Spark.Dsl.Verifier
   alias Spark.Error.DslError
 
+  # The transformer tags actions which belong to no strategy with this name, so
+  # it is always a valid `include_strategies` entry. It is also the default name
+  # of the add-on itself, but it stays valid when the add-on is renamed.
+  @no_strategy :audit_log
+
   @doc false
   @impl true
   def verify(dsl) do
@@ -25,6 +30,8 @@ defmodule AshAuthentication.AddOn.AuditLog.Verifier do
 
   defp do_verify(strategy) do
     with :ok <- verify_audit_log_resource(strategy),
+         :ok <- verify_include_strategies(strategy),
+         :ok <- verify_include_actions(strategy),
          :ok <- verify_exclude_strategies(strategy),
          :ok <- verify_exclude_actions(strategy),
          :ok <- verify_truncation_masks(strategy) do
@@ -53,6 +60,76 @@ defmodule AshAuthentication.AddOn.AuditLog.Verifier do
 
       true ->
         :ok
+    end
+  end
+
+  defp verify_include_strategies(strategy) when strategy.include_strategies == [], do: :ok
+
+  defp verify_include_strategies(strategy) do
+    strategy.include_strategies
+    |> Enum.reject(
+      &(&1 == @no_strategy or AshAuthentication.Info.strategy_present?(strategy.resource, &1))
+    )
+    |> case do
+      [] ->
+        :ok
+
+      [missing_strategy] ->
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_strategies],
+           message:
+             "The strategy or add-on `#{inspect(missing_strategy)}` is not present on the resource `#{inspect(strategy.resource)}`."
+         )}
+
+      missing_strategies ->
+        missing_strategies = Enum.map_join(missing_strategies, "\n  - ", &"`#{inspect(&1)}`")
+
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_strategies],
+           message: """
+           The following strategies or add-ons are not present on the resource `#{inspect(strategy.resource)}`:
+
+           - #{missing_strategies}
+           """
+         )}
+    end
+  end
+
+  defp verify_include_actions(strategy) when strategy.include_actions == [], do: :ok
+
+  defp verify_include_actions(strategy) do
+    strategy.include_actions
+    |> Enum.reject(&Ash.Resource.Info.action(strategy.resource, &1))
+    |> case do
+      [] ->
+        :ok
+
+      [missing_action] ->
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_actions],
+           message:
+             "The action `#{inspect(missing_action)}` is not present on the resource `#{inspect(strategy.resource)}`."
+         )}
+
+      missing_actions ->
+        missing_actions = Enum.map_join(missing_actions, "\n  - ", &"`#{inspect(&1)}`")
+
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_actions],
+           message: """
+           The following actions are not present on the resource `#{inspect(strategy.resource)}`:
+
+           - #{missing_actions}
+           """
+         )}
     end
   end
 

--- a/test/ash_authentication/add_ons/audit_log/transformer_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/transformer_test.exs
@@ -85,17 +85,42 @@ defmodule AshAuthentication.AddOn.AuditLog.TransformerTest do
       assert :register_with_password in tracked_actions
     end
 
-    test "strategy-level filtering applies to included actions" do
-      # UserWithSelectiveStrategyIncludes only includes [:password] strategy
+    test "actions belonging to strategies outside include_strategies are not tracked" do
+      # UserWithSelectiveStrategyIncludes has password and magic_link strategies,
+      # but only includes [:password]
       _strategy = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :audit_log)
 
       tracked_actions =
         Auditor.get_tracked_actions(Example.UserWithSelectiveStrategyIncludes, :audit_log)
 
-      # All tracked actions should belong to password strategy
       assert :sign_in_with_password in tracked_actions
       assert :register_with_password in tracked_actions
-      # If there were actions from other strategies, they wouldn't be included
+
+      magic_link = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :magic_link)
+
+      for action_name <- [magic_link.request_action_name, magic_link.sign_in_action_name] do
+        refute action_name in tracked_actions
+      end
+    end
+
+    test "actions belonging to no strategy are not tracked when include_strategies is narrowed" do
+      _strategy = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :audit_log)
+
+      tracked_actions =
+        Auditor.get_tracked_actions(Example.UserWithSelectiveStrategyIncludes, :audit_log)
+
+      for action_name <- [:read, :create, :update, :destroy] do
+        refute action_name in tracked_actions
+      end
+    end
+
+    test "actions belonging to no strategy are tracked when include_strategies is the wildcard" do
+      # UserWithAuditLog uses the default include_strategies: [:*]
+      tracked_actions = Auditor.get_tracked_actions(Example.UserWithAuditLog, :audit_log)
+
+      for action_name <- [:read, :create, :update, :destroy] do
+        assert action_name in tracked_actions
+      end
     end
   end
 

--- a/test/ash_authentication/add_ons/audit_log/verifier_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/verifier_test.exs
@@ -7,6 +7,11 @@ defmodule AshAuthentication.AddOn.AuditLog.VerifierTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureIO
 
+  alias AshAuthentication.AddOn.AuditLog.Verifier
+  alias AshAuthentication.Info
+  alias Spark.Dsl.Transformer
+  alias Spark.Error.DslError
+
   defmodule TestDomain do
     @moduledoc false
     use Ash.Domain, validate_config_inclusion?: false
@@ -474,5 +479,163 @@ defmodule AshAuthentication.AddOn.AuditLog.VerifierTest do
       # Should not crash, and should not show warning for non-existent fields
       refute log_output =~ "AuditLog is configured to log sensitive fields"
     end
+  end
+
+  describe "include option types" do
+    test "a non-atom `include_strategies` value is rejected" do
+      assert_raise DslError, ~r/include_strategies/, fn ->
+        defmodule UserWithStringIncludeStrategies do
+          @moduledoc false
+          use Ash.Resource,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshAuthentication],
+            domain: TestDomain
+
+          attributes do
+            uuid_primary_key :id
+            attribute :email, :ci_string, allow_nil?: false, public?: true
+            attribute :hashed_password, :string, allow_nil?: true, sensitive?: true
+          end
+
+          actions do
+            defaults [:read, :create, :update, :destroy]
+          end
+
+          authentication do
+            tokens do
+              enabled? true
+              token_resource Example.Token
+              signing_secret "test_secret_at_least_64_characters_long_for_proper_security"
+            end
+
+            add_ons do
+              audit_log do
+                audit_log_resource TestAuditLog
+                include_strategies "password"
+              end
+            end
+
+            strategies do
+              password do
+                identity_field :email
+              end
+            end
+          end
+
+          identities do
+            identity :unique_email, [:email]
+          end
+        end
+      end
+    end
+
+    test "a non-atom `include_actions` value is rejected" do
+      assert_raise DslError, ~r/include_actions/, fn ->
+        defmodule UserWithStringIncludeActions do
+          @moduledoc false
+          use Ash.Resource,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshAuthentication],
+            domain: TestDomain
+
+          attributes do
+            uuid_primary_key :id
+            attribute :email, :ci_string, allow_nil?: false, public?: true
+            attribute :hashed_password, :string, allow_nil?: true, sensitive?: true
+          end
+
+          actions do
+            defaults [:read, :create, :update, :destroy]
+          end
+
+          authentication do
+            tokens do
+              enabled? true
+              token_resource Example.Token
+              signing_secret "test_secret_at_least_64_characters_long_for_proper_security"
+            end
+
+            add_ons do
+              audit_log do
+                audit_log_resource TestAuditLog
+                include_actions "sign_in_with_password"
+              end
+            end
+
+            strategies do
+              password do
+                identity_field :email
+              end
+            end
+          end
+
+          identities do
+            identity :unique_email, [:email]
+          end
+        end
+      end
+    end
+  end
+
+  describe "verify_include_strategies/1" do
+    test "an unknown strategy name is rejected" do
+      dsl_state = replace_audit_log(Example.UserWithAuditLog, include_strategies: [:pasword])
+
+      assert {:error, %DslError{} = error} = Verifier.verify(dsl_state)
+
+      assert error.path == [
+               :authentication,
+               :add_ons,
+               :audit_log,
+               :audit_log,
+               :include_strategies
+             ]
+
+      assert Exception.message(error) =~ "`:pasword` is not present"
+    end
+
+    test "every unknown strategy name is listed" do
+      dsl_state =
+        replace_audit_log(Example.UserWithAuditLog, include_strategies: [:pasword, :magik_link])
+
+      assert {:error, %DslError{} = error} = Verifier.verify(dsl_state)
+
+      message = Exception.message(error)
+
+      assert message =~ "`:pasword`"
+      assert message =~ "`:magik_link`"
+    end
+
+    test "the marker for actions without a strategy stays valid when the add-on is renamed" do
+      strategy = Info.strategy!(Example.UserWithRenamedAuditLog, :security_log)
+
+      assert :audit_log in strategy.include_strategies
+      refute Info.strategy_present?(Example.UserWithRenamedAuditLog, :audit_log)
+
+      assert :ok = Verifier.verify(Example.UserWithRenamedAuditLog.spark_dsl_config())
+    end
+  end
+
+  describe "verify_include_actions/1" do
+    test "an unknown action name is rejected" do
+      dsl_state =
+        replace_audit_log(Example.UserWithAuditLog, include_actions: [:sign_in_with_pasword])
+
+      assert {:error, %DslError{} = error} = Verifier.verify(dsl_state)
+
+      assert error.path == [:authentication, :add_ons, :audit_log, :audit_log, :include_actions]
+      assert Exception.message(error) =~ "`:sign_in_with_pasword` is not present"
+    end
+  end
+
+  defp replace_audit_log(resource, attrs) do
+    strategy = Info.strategy!(resource, :audit_log)
+
+    Transformer.replace_entity(
+      resource.spark_dsl_config(),
+      [:authentication, :add_ons],
+      struct!(strategy, attrs),
+      &(&1.name == :audit_log)
+    )
   end
 end

--- a/test/ash_authentication_test.exs
+++ b/test/ash_authentication_test.exs
@@ -22,6 +22,7 @@ defmodule AshAuthenticationTest do
                Example.UserWithOtp,
                Example.UserWithRecoveryCodes,
                Example.UserWithRegisterOtp,
+               Example.UserWithRenamedAuditLog,
                Example.UserWithSelectiveStrategyIncludes,
                Example.UserWithTokenRequired,
                Example.UserWithTotp,

--- a/test/support/example.ex
+++ b/test/support/example.ex
@@ -25,6 +25,7 @@ defmodule Example do
     resource Example.UserWithFailingSender
     resource Example.UserWithRegisterMagicLink
     resource Example.UserWithRememberMe
+    resource Example.UserWithRenamedAuditLog
     resource Example.UserWithSelectiveStrategyIncludes
     resource Example.UserWithTokenRequired
     resource Example.UserWithTotp

--- a/test/support/example/user_with_renamed_audit_log.ex
+++ b/test/support/example/user_with_renamed_audit_log.ex
@@ -2,15 +2,16 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule Example.UserWithSelectiveStrategyIncludes do
+defmodule Example.UserWithRenamedAuditLog do
   @moduledoc """
-  Test resource that only includes specific strategies for audit logging.
+  Test resource whose audit log add-on does not use the default name.
 
-  Only actions belonging to the `password` strategy should be logged; the
-  `magic_link` actions and the actions which belong to no strategy should not.
+  The transformer marks actions which belong to no strategy with the name
+  `:audit_log`, which is also the default name of the add-on. This resource
+  proves that the marker stays valid when no add-on carries that name.
   """
   use Ash.Resource,
-    data_layer: AshPostgres.DataLayer,
+    data_layer: Ash.DataLayer.Ets,
     extensions: [AshAuthentication],
     domain: Example
 
@@ -27,11 +28,6 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
     defaults [:read, :destroy, create: :*, update: :*]
   end
 
-  postgres do
-    table "users_with_selective_strategy_includes"
-    repo(Example.Repo)
-  end
-
   authentication do
     session_identifier :jti
 
@@ -43,15 +39,8 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
     end
 
     add_ons do
-      audit_log do
+      audit_log :security_log do
         audit_log_resource(Example.AuditLog)
-        # Only include password strategy actions, not the audit_log add-on itself
-        include_strategies([:password])
-        # Include all actions for included strategies
-        include_actions([:*])
-        # No exclusions
-        exclude_strategies([])
-        exclude_actions([])
       end
     end
 
@@ -59,21 +48,11 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
       password do
         identity_field :email
       end
-
-      magic_link do
-        identity_field :email
-        sender fn _user, _token, _opts -> :ok end
-      end
     end
   end
 
   identities do
-    identity :unique_email, [:email]
-  end
-
-  code_interface do
-    define :sign_in_with_password
-    define :register_with_password
+    identity :unique_email, [:email], pre_check_with: Example
   end
 
   def get_config(path, _resource) do


### PR DESCRIPTION
## The defect

`AshAuthentication.AddOn.AuditLog.Transformer.find_logged_actions/2` never read
`include_strategies`. The option was accepted, normalised onto the entity and
then ignored. It has never worked in any released version on either line:

```
git log --all -S include_strategies -- lib/
```

matches only the commit which introduced it.

An operator who set `include_strategies [:password]` still got every other
strategy audited, plus every action which belongs to no strategy. The add-on
gave no sign of this.

The effect was always over-collection, never under-collection. The broken code
produced a superset of the configured scope.

## What changed

**1. The filter.** `find_logged_actions/2` now filters the action list by
`include_strategies`. The magic atom which tags actions belonging to no strategy
becomes a module attribute, `@no_strategy :audit_log`.

**2. Schema types.** `include_strategies` and `include_actions` had no `type:`
at all, so Spark defaulted them to `:any` and `include_strategies "banana"`
compiled. Both now carry `type: {:wrap_list, :atom}`, which is what
`exclude_strategies` and `exclude_actions` already used.

**3. Name validation.** The verifier gains `verify_include_strategies/1` and
`verify_include_actions/1`, alongside the existing checks for the two exclude
options.

This covers a regression the filter fix introduces. Before the fix,
`include_strategies [:pasword]` was harmless, because the option was inert and
everything got logged. After the fix, that typo matches nothing and the resource
silently logs **nothing at all**. Validation turns it into a compile error.

**4. Tests.** The old strategy-filtering test was vacuous: its negative assertion
was a comment, and the fixture had only one strategy, so there was nothing to
exclude. The fixture gains a `magic_link` strategy, and the test becomes three
real ones. New tests cover the schema types, both verifiers and the renamed
add-on case below.

## The `[:*]` decision

Under the default `include_strategies [:*]`, `prefill_included_strategies/2` now
expands to every strategy name **plus** the `@no_strategy` marker. So actions
which belong to no strategy keep being audited exactly as they are today. A
resource on defaults sees no behaviour change.

When `include_strategies` is narrowed, the marker is absent, so actions outside
any strategy are excluded. That is what the option claims to do, and it matches
what the test fixture's docstring implies.

## The renamed add-on trap

`AshAuthentication.Info.strategy_present?/2` and `list_strategies/1` both include
add-ons as well as strategies. The `@no_strategy` marker is the atom
`:audit_log`, which is also the audit-log add-on's default name. So:

- With a default-named add-on, `strategy_present?(resource, :audit_log)` is
  `true`, and naive validation happens to pass.
- With a renamed add-on — `audit_log :security_log` — the expanded `[:*]` list
  still contains the `:audit_log` marker, but
  `strategy_present?(resource, :audit_log)` is now `false`. Naive validation
  would reject it and break compilation for every resource with a renamed
  audit-log add-on.

`verify_include_strategies/1` therefore treats the marker as always valid,
independently of whether an add-on shares its name. The verifier carries its own
`@no_strategy`; a verifier which depends on a transformer would be worse.

`Example.UserWithRenamedAuditLog` covers this. Because it is a compiled test
support fixture, a naive verifier breaks the whole suite rather than one test.

The shared name is a wart. The marker and the add-on's default name should not
be the same atom. That is worth addressing separately, because changing the
marker changes the value written to the `strategy` column of existing audit
tables.

## Consequence for operators

If you set `include_strategies`, your audit table already holds rows for
strategies you thought you had excluded. They carry the out-of-scope name in the
`strategy` column, so one delete removes them:

```sql
DELETE FROM audit_logs WHERE strategy NOT IN ('password');
```

After you upgrade, coverage shrinks to what your config always claimed. Review
any dashboard, alert or downstream consumer which reads the audit table, because
rows it used to see will stop arriving.

The brute-force verifiers already fail the compile if a protected action stops
being logged, so that path fails safe.

## Noted follow-up

`verify_exclude_strategies/1` and `verify_exclude_actions/1` each contain a
near-identical singular/plural `DslError` construction, and the two new functions
make four copies. This PR matches that style rather than extracting a helper.
This fix is destined for backport to `stable-4.0`, and touching working
validation code to tidy it trades a real regression risk for cosmetics. The
duplication is worth collapsing in a separate change.
