### PR TITLE
fix(audit_log): make `include_strategies` filter the logged actions

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
+++ b/documentation/dsls/DSL-AshAuthentication.AddOn.AuditLog.md
@@ -73,8 +73,8 @@ end
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`audit_log_resource`](#authentication-add_ons-audit_log-audit_log_resource){: #authentication-add_ons-audit_log-audit_log_resource .spark-required} | `module` |  | The name of the Audit Log resource. |
-| [`include_strategies`](#authentication-add_ons-audit_log-include_strategies){: #authentication-add_ons-audit_log-include_strategies } | `nil` | `[:*]` | Explicitly allow events from the named strategies. |
-| [`include_actions`](#authentication-add_ons-audit_log-include_actions){: #authentication-add_ons-audit_log-include_actions } | `nil` | `[:*]` | Explicitly allow events from the named actions. |
+| [`include_strategies`](#authentication-add_ons-audit_log-include_strategies){: #authentication-add_ons-audit_log-include_strategies } | `atom \| list(atom)` | `[:*]` | Explicitly allow events from the named strategies. |
+| [`include_actions`](#authentication-add_ons-audit_log-include_actions){: #authentication-add_ons-audit_log-include_actions } | `atom \| list(atom)` | `[:*]` | Explicitly allow events from the named actions. |
 | [`exclude_strategies`](#authentication-add_ons-audit_log-exclude_strategies){: #authentication-add_ons-audit_log-exclude_strategies } | `atom \| list(atom)` | `[]` | Explicitly ignore events from the named strategies. |
 | [`exclude_actions`](#authentication-add_ons-audit_log-exclude_actions){: #authentication-add_ons-audit_log-exclude_actions } | `atom \| list(atom)` | `[]` | Explicitly ignore events from the named actions. |
 | [`include_fields`](#authentication-add_ons-audit_log-include_fields){: #authentication-add_ons-audit_log-include_fields } | `atom \| list(atom)` | `[]` | Explicitly include named attributes and arguments in the audit log regardless of their sensitivity setting. |

--- a/lib/ash_authentication/add_ons/audit_log/dsl.ex
+++ b/lib/ash_authentication/add_ons/audit_log/dsl.ex
@@ -50,10 +50,12 @@ defmodule AshAuthentication.AddOn.AuditLog.Dsl do
           required: true
         ],
         include_strategies: [
+          type: {:wrap_list, :atom},
           doc: "Explicitly allow events from the named strategies.",
           default: [:*]
         ],
         include_actions: [
+          type: {:wrap_list, :atom},
           doc: "Explicitly allow events from the named actions.",
           default: [:*]
         ],

--- a/lib/ash_authentication/add_ons/audit_log/transformer.ex
+++ b/lib/ash_authentication/add_ons/audit_log/transformer.ex
@@ -6,6 +6,8 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
   @moduledoc false
   alias Spark.Dsl.Transformer
 
+  @no_strategy :audit_log
+
   @doc false
   def transform(strategy, dsl) do
     with {:ok, strategy, dsl} <- prefill_included(strategy, dsl),
@@ -35,6 +37,8 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
       dsl
       |> AshAuthentication.Info.list_strategies()
       |> Enum.map(& &1.name)
+      |> Enum.concat([@no_strategy])
+      |> Enum.uniq()
 
     {:ok, %{strategy | include_strategies: strategy_names}}
   end
@@ -56,13 +60,12 @@ defmodule AshAuthentication.AddOn.AuditLog.Transformer do
     logged_actions =
       strategy.include_actions
       |> Stream.map(fn action_name ->
-        # For actions that belong to a strategy, use the strategy name
-        # For actions that don't belong to any strategy, use :audit_log as the strategy
         case AshAuthentication.Info.strategy_for_action(dsl, action_name) do
           {:ok, action_strategy} -> {action_name, action_strategy.name}
-          :error -> {action_name, :audit_log}
+          :error -> {action_name, @no_strategy}
         end
       end)
+      |> Stream.filter(&(elem(&1, 1) in strategy.include_strategies))
       |> Stream.reject(&(elem(&1, 0) in strategy.exclude_actions))
       |> Stream.reject(&(elem(&1, 1) in strategy.exclude_strategies))
       |> Enum.to_list()

--- a/lib/ash_authentication/add_ons/audit_log/verifier.ex
+++ b/lib/ash_authentication/add_ons/audit_log/verifier.ex
@@ -9,9 +9,16 @@ defmodule AshAuthentication.AddOn.AuditLog.Verifier do
 
   alias Spark.Error.DslError
 
+  # The transformer tags actions which belong to no strategy with this name, so
+  # it is always a valid `include_strategies` entry. It is also the default name
+  # of the add-on itself, but it stays valid when the add-on is renamed.
+  @no_strategy :audit_log
+
   @doc false
   def verify(strategy, _dsl) do
     with :ok <- verify_audit_log_resource(strategy),
+         :ok <- verify_include_strategies(strategy),
+         :ok <- verify_include_actions(strategy),
          :ok <- verify_exclude_strategies(strategy),
          :ok <- verify_exclude_actions(strategy),
          :ok <- verify_truncation_masks(strategy) do
@@ -40,6 +47,76 @@ defmodule AshAuthentication.AddOn.AuditLog.Verifier do
 
       true ->
         :ok
+    end
+  end
+
+  defp verify_include_strategies(strategy) when strategy.include_strategies == [], do: :ok
+
+  defp verify_include_strategies(strategy) do
+    strategy.include_strategies
+    |> Enum.reject(
+      &(&1 == @no_strategy or AshAuthentication.Info.strategy_present?(strategy.resource, &1))
+    )
+    |> case do
+      [] ->
+        :ok
+
+      [missing_strategy] ->
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_strategies],
+           message:
+             "The strategy or add-on `#{inspect(missing_strategy)}` is not present on the resource `#{inspect(strategy.resource)}`."
+         )}
+
+      missing_strategies ->
+        missing_strategies = Enum.map_join(missing_strategies, "\n  - ", &"`#{inspect(&1)}`")
+
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_strategies],
+           message: """
+           The following strategies or add-ons are not present on the resource `#{inspect(strategy.resource)}`:
+
+           - #{missing_strategies}
+           """
+         )}
+    end
+  end
+
+  defp verify_include_actions(strategy) when strategy.include_actions == [], do: :ok
+
+  defp verify_include_actions(strategy) do
+    strategy.include_actions
+    |> Enum.reject(&Ash.Resource.Info.action(strategy.resource, &1))
+    |> case do
+      [] ->
+        :ok
+
+      [missing_action] ->
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_actions],
+           message:
+             "The action `#{inspect(missing_action)}` is not present on the resource `#{inspect(strategy.resource)}`."
+         )}
+
+      missing_actions ->
+        missing_actions = Enum.map_join(missing_actions, "\n  - ", &"`#{inspect(&1)}`")
+
+        {:error,
+         DslError.exception(
+           module: strategy.resource,
+           path: [:authentication, :add_ons, :audit_log, strategy.name, :include_actions],
+           message: """
+           The following actions are not present on the resource `#{inspect(strategy.resource)}`:
+
+           - #{missing_actions}
+           """
+         )}
     end
   end
 

--- a/test/ash_authentication/add_ons/audit_log/transformer_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/transformer_test.exs
@@ -85,17 +85,42 @@ defmodule AshAuthentication.AddOn.AuditLog.TransformerTest do
       assert :register_with_password in tracked_actions
     end
 
-    test "strategy-level filtering applies to included actions" do
-      # UserWithSelectiveStrategyIncludes only includes [:password] strategy
+    test "actions belonging to strategies outside include_strategies are not tracked" do
+      # UserWithSelectiveStrategyIncludes has password and magic_link strategies,
+      # but only includes [:password]
       _strategy = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :audit_log)
 
       tracked_actions =
         Auditor.get_tracked_actions(Example.UserWithSelectiveStrategyIncludes, :audit_log)
 
-      # All tracked actions should belong to password strategy
       assert :sign_in_with_password in tracked_actions
       assert :register_with_password in tracked_actions
-      # If there were actions from other strategies, they wouldn't be included
+
+      magic_link = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :magic_link)
+
+      for action_name <- [magic_link.request_action_name, magic_link.sign_in_action_name] do
+        refute action_name in tracked_actions
+      end
+    end
+
+    test "actions belonging to no strategy are not tracked when include_strategies is narrowed" do
+      _strategy = Info.strategy!(Example.UserWithSelectiveStrategyIncludes, :audit_log)
+
+      tracked_actions =
+        Auditor.get_tracked_actions(Example.UserWithSelectiveStrategyIncludes, :audit_log)
+
+      for action_name <- [:read, :create, :update, :destroy] do
+        refute action_name in tracked_actions
+      end
+    end
+
+    test "actions belonging to no strategy are tracked when include_strategies is the wildcard" do
+      # UserWithAuditLog uses the default include_strategies: [:*]
+      tracked_actions = Auditor.get_tracked_actions(Example.UserWithAuditLog, :audit_log)
+
+      for action_name <- [:read, :create, :update, :destroy] do
+        assert action_name in tracked_actions
+      end
     end
   end
 

--- a/test/ash_authentication/add_ons/audit_log/verifier_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/verifier_test.exs
@@ -7,6 +7,10 @@ defmodule AshAuthentication.AddOn.AuditLog.VerifierTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureIO
 
+  alias AshAuthentication.AddOn.AuditLog.Verifier
+  alias AshAuthentication.Info
+  alias Spark.Error.DslError
+
   defmodule TestDomain do
     @moduledoc false
     use Ash.Domain, validate_config_inclusion?: false
@@ -474,5 +478,157 @@ defmodule AshAuthentication.AddOn.AuditLog.VerifierTest do
       # Should not crash, and should not show warning for non-existent fields
       refute log_output =~ "AuditLog is configured to log sensitive fields"
     end
+  end
+
+  describe "include option types" do
+    test "a non-atom `include_strategies` value is rejected" do
+      assert_raise DslError, ~r/include_strategies/, fn ->
+        defmodule UserWithStringIncludeStrategies do
+          @moduledoc false
+          use Ash.Resource,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshAuthentication],
+            domain: TestDomain
+
+          attributes do
+            uuid_primary_key :id
+            attribute :email, :ci_string, allow_nil?: false, public?: true
+            attribute :hashed_password, :string, allow_nil?: true, sensitive?: true
+          end
+
+          actions do
+            defaults [:read, :create, :update, :destroy]
+          end
+
+          authentication do
+            tokens do
+              enabled? true
+              token_resource Example.Token
+              signing_secret "test_secret_at_least_64_characters_long_for_proper_security"
+            end
+
+            add_ons do
+              audit_log do
+                audit_log_resource TestAuditLog
+                include_strategies "password"
+              end
+            end
+
+            strategies do
+              password do
+                identity_field :email
+              end
+            end
+          end
+
+          identities do
+            identity :unique_email, [:email]
+          end
+        end
+      end
+    end
+
+    test "a non-atom `include_actions` value is rejected" do
+      assert_raise DslError, ~r/include_actions/, fn ->
+        defmodule UserWithStringIncludeActions do
+          @moduledoc false
+          use Ash.Resource,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshAuthentication],
+            domain: TestDomain
+
+          attributes do
+            uuid_primary_key :id
+            attribute :email, :ci_string, allow_nil?: false, public?: true
+            attribute :hashed_password, :string, allow_nil?: true, sensitive?: true
+          end
+
+          actions do
+            defaults [:read, :create, :update, :destroy]
+          end
+
+          authentication do
+            tokens do
+              enabled? true
+              token_resource Example.Token
+              signing_secret "test_secret_at_least_64_characters_long_for_proper_security"
+            end
+
+            add_ons do
+              audit_log do
+                audit_log_resource TestAuditLog
+                include_actions "sign_in_with_password"
+              end
+            end
+
+            strategies do
+              password do
+                identity_field :email
+              end
+            end
+          end
+
+          identities do
+            identity :unique_email, [:email]
+          end
+        end
+      end
+    end
+  end
+
+  describe "verify_include_strategies/1" do
+    test "an unknown strategy name is rejected" do
+      assert {:error, %DslError{} = error} =
+               verify_audit_log(Example.UserWithAuditLog, include_strategies: [:pasword])
+
+      assert error.path == [
+               :authentication,
+               :add_ons,
+               :audit_log,
+               :audit_log,
+               :include_strategies
+             ]
+
+      assert Exception.message(error) =~ "`:pasword` is not present"
+    end
+
+    test "every unknown strategy name is listed" do
+      assert {:error, %DslError{} = error} =
+               verify_audit_log(Example.UserWithAuditLog,
+                 include_strategies: [:pasword, :magik_link]
+               )
+
+      message = Exception.message(error)
+
+      assert message =~ "`:pasword`"
+      assert message =~ "`:magik_link`"
+    end
+
+    test "the marker for actions without a strategy stays valid when the add-on is renamed" do
+      strategy = Info.strategy!(Example.UserWithRenamedAuditLog, :security_log)
+
+      assert :audit_log in strategy.include_strategies
+      refute Info.strategy_present?(Example.UserWithRenamedAuditLog, :audit_log)
+
+      assert :ok = Verifier.verify(strategy, Example.UserWithRenamedAuditLog.spark_dsl_config())
+    end
+  end
+
+  describe "verify_include_actions/1" do
+    test "an unknown action name is rejected" do
+      assert {:error, %DslError{} = error} =
+               verify_audit_log(Example.UserWithAuditLog,
+                 include_actions: [:sign_in_with_pasword]
+               )
+
+      assert error.path == [:authentication, :add_ons, :audit_log, :audit_log, :include_actions]
+      assert Exception.message(error) =~ "`:sign_in_with_pasword` is not present"
+    end
+  end
+
+  defp verify_audit_log(resource, attrs) do
+    strategy = Info.strategy!(resource, :audit_log)
+
+    Verifier.verify(struct!(strategy, attrs), resource.spark_dsl_config())
   end
 end

--- a/test/ash_authentication_test.exs
+++ b/test/ash_authentication_test.exs
@@ -17,6 +17,7 @@ defmodule AshAuthenticationTest do
                Example.UserWithExcludedActions,
                Example.UserWithExcludedStrategies,
                Example.UserWithExplicitIncludes,
+               Example.UserWithRenamedAuditLog,
                Example.UserWithSelectiveStrategyIncludes,
                Example.UserWithTokenRequired,
                Example.UserWithRememberMe,

--- a/test/support/example.ex
+++ b/test/support/example.ex
@@ -20,6 +20,7 @@ defmodule Example do
     resource Example.UserWithExplicitIncludes
     resource Example.UserWithRegisterMagicLink
     resource Example.UserWithRememberMe
+    resource Example.UserWithRenamedAuditLog
     resource Example.UserWithSelectiveStrategyIncludes
     resource Example.UserWithTokenRequired
     resource Example.UserWithWildcardAndExclusions

--- a/test/support/example/user_with_renamed_audit_log.ex
+++ b/test/support/example/user_with_renamed_audit_log.ex
@@ -2,15 +2,16 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule Example.UserWithSelectiveStrategyIncludes do
+defmodule Example.UserWithRenamedAuditLog do
   @moduledoc """
-  Test resource that only includes specific strategies for audit logging.
+  Test resource whose audit log add-on does not use the default name.
 
-  Only actions belonging to the `password` strategy should be logged; the
-  `magic_link` actions and the actions which belong to no strategy should not.
+  The transformer marks actions which belong to no strategy with the name
+  `:audit_log`, which is also the default name of the add-on. This resource
+  proves that the marker stays valid when no add-on carries that name.
   """
   use Ash.Resource,
-    data_layer: AshPostgres.DataLayer,
+    data_layer: Ash.DataLayer.Ets,
     extensions: [AshAuthentication],
     domain: Example
 
@@ -27,11 +28,6 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
     defaults [:read, :destroy, create: :*, update: :*]
   end
 
-  postgres do
-    table "users_with_selective_strategy_includes"
-    repo(Example.Repo)
-  end
-
   authentication do
     session_identifier :jti
 
@@ -43,15 +39,8 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
     end
 
     add_ons do
-      audit_log do
+      audit_log :security_log do
         audit_log_resource(Example.AuditLog)
-        # Only include password strategy actions, not the audit_log add-on itself
-        include_strategies([:password])
-        # Include all actions for included strategies
-        include_actions([:*])
-        # No exclusions
-        exclude_strategies([])
-        exclude_actions([])
       end
     end
 
@@ -59,21 +48,11 @@ defmodule Example.UserWithSelectiveStrategyIncludes do
       password do
         identity_field :email
       end
-
-      magic_link do
-        identity_field :email
-        sender fn _user, _token, _opts -> :ok end
-      end
     end
   end
 
   identities do
-    identity :unique_email, [:email]
-  end
-
-  code_interface do
-    define :sign_in_with_password
-    define :register_with_password
+    identity :unique_email, [:email], pre_check_with: Example
   end
 
   def get_config(path, _resource) do


### PR DESCRIPTION
Backport of #1208 to the `stable-4.0` line.

## What was wrong

`find_logged_actions/2` never read `include_strategies`. The option was accepted, normalised onto the entity and then ignored, so the add-on logged every strategy and every non-strategy action whatever the config said. The option has never worked in any released version.

## Operator guidance

The effect was always over-collection, never under-collection. If you set `include_strategies`, your audit table already holds rows for strategies you excluded. They carry the out-of-scope name in the `strategy` column, so one delete removes them:

```sql
DELETE FROM audit_logs WHERE strategy NOT IN ('password');
```

After you upgrade, coverage shrinks to what your config always claimed. Review any dashboard, alert or downstream consumer which reads the audit table, because rows it used to see will stop arriving.

`include_strategies [:*, :password]` compiled before this change and now fails verification. The wildcard is only expanded when it is the entire list, so in a mixed list `:*` was an inert literal matching no strategy. After this change it would silently narrow the list to `[:password]`, so it is rejected as an unknown strategy instead. Write `[:*]` on its own, or name every strategy you want logged.

## The change

1. `find_logged_actions/2` now filters the action list by `include_strategies`.
2. `include_strategies` and `include_actions` gain `type: {:wrap_list, :atom}`, which matches `exclude_strategies` and `exclude_actions`. Both accepted any term before.
3. The verifier gains `verify_include_strategies/1` and `verify_include_actions/1`. Before the filter fix a misspelt name was harmless, because the option did nothing. Now a misspelt name matches no action and the resource logs nothing at all.
4. The wildcard `[:*]` expands to every strategy name plus the `:audit_log` marker which tags actions belonging to no strategy. A resource on the default therefore logs exactly what it logs today. Narrowing `include_strategies` drops the marker.

The marker shares its name with the default name of the add-on. The verifier treats it as always valid, so a renamed add-on such as `audit_log :security_log` still compiles.

## Differences from the change on `main`

- **The changelog body drops one sentence.** The original said the brute force verifiers fail the compile if a protected action stops being logged. That machinery does not exist on this line, so the claim would be false here.
- **The verifier has a different shape.** `main` has `verify/1` delegating to `do_verify/1`. This line has `verify/2`, which the add-on calls with the strategy already extracted. The two new checks go into that `with` chain in the same relative position.
- **The verifier tests call `verify/2` directly.** `main` rebuilds the DSL state with `Spark.Dsl.Transformer.replace_entity/4` because `verify/1` reads the strategy back out of it. Here the strategy is an argument, so the test helper passes an amended struct straight in. Same assertions, less scaffolding.
- **`Example.UserWithRenamedAuditLog` is new on this line.** It is a compiled support fixture rather than an inline `defmodule`, because verifier errors raised inside a runtime `defmodule` are downgraded to warnings, which would make the test pass even against a naive verifier. It uses `Ash.DataLayer.Ets` so it needs no migration.
- **`test/ash_authentication_test.exs` asserts an exact `authenticated_resources/0` list here too**, so the new fixture is registered there and in the `Example` domain.

Everything else ports across unchanged: `find_logged_actions/2`, `prefill_included_strategies/2`, the DSL schema and `test/support/example/user_with_selective_strategy_includes.ex` were byte-identical between the two lines before the change.

## Verification

Both new transformer tests and all six new verifier tests were confirmed to fail against the unmodified branch first. The transformer failures showed the tracked action list containing every action despite `include_strategies [:password]`.

`mix check --no-retry` passes on every tool. `reuse` cannot start in this environment — the pipx-cached package raises `NoEncodingModuleError` at import time under Python 3.14, before it reads any file, so even `reuse --version` fails. Run with the missing extra it reports full compliance: 402/402 files with copyright and licence information, including the new fixture.