### PR TITLE
docs: describe request action timing and account enumeration

### DIFF
--- a/documentation/tutorials/magic-links.md
+++ b/documentation/tutorials/magic-links.md
@@ -112,3 +112,23 @@ end
 
 # ...
 ```
+
+## Request timing and account enumeration
+
+The request action returns `:ok` whether or not the identity matches a user. The
+response body therefore does not reveal which accounts exist. The response *time*
+is a different matter. When the identity matches, the action mints a token and
+calls your sender inline. When it does not match, it does neither. A synchronous
+SMTP or HTTP-API send takes tens to hundreds of milliseconds. That gap is easy to
+measure, so it separates known identities from unknown ones.
+
+The sender is the part you control, and it is the part that leaks. Make it
+asynchronous. A sender that enqueues a job and returns `:ok` immediately keeps
+delivery latency off both paths. What remains is one JWT signing operation, about
+27 microseconds. Neither path writes to the database unless you enable
+`store_all_tokens?`. A difference that small is not measurable across a network.
+See `AshAuthentication.Sender`, which recommends the same pattern for retries.
+
+This only applies when `registration_enabled?` is `false`, which is the default. With registration
+enabled, both paths mint a token and call the sender. The remaining difference is
+then around 3 microseconds.

--- a/documentation/tutorials/otp.md
+++ b/documentation/tutorials/otp.md
@@ -108,6 +108,23 @@ The audit log add-on tracks all authentication actions by default, so there's no
 need to list them explicitly — failures on `request_otp` and `sign_in_with_otp`
 will both count toward the `audit_log_max_failures` threshold.
 
+### Request timing and account enumeration
+
+The request action returns `:ok` whether or not the identity matches a user, so the
+response body does not reveal which accounts exist. The response time is not
+uniform. With `registration_enabled?` set to `false` (the default), a match
+generates a code, signs a token, writes that token to the token resource and calls
+your sender. A miss does none of that work. The synchronous send alone takes tens
+to hundreds of milliseconds against an SMTP or HTTP API, which is enough to
+separate the two paths.
+
+An asynchronous sender removes the largest part of that difference. A sender that
+enqueues a job and returns `:ok` immediately keeps delivery latency off both paths
+— see `AshAuthentication.Sender`. OTP still leaves a wider gap than the other
+request-style strategies, because it stores its token unconditionally. That
+database insert happens on the match path only, whatever `store_all_tokens?` is set
+to.
+
 ## Prerequisites
 
 Your user resource needs:
@@ -270,7 +287,8 @@ The OTP strategy uses a deterministic JTI (JWT ID) to map short codes back to st
 3. A JWT is created with a deterministic JTI derived from `(strategy_name, user_subject, otp_code)`
 4. The JWT is stored in the token resource with purpose `"otp"`
 5. The short code is sent to the user via the sender
-6. Returns `:ok` regardless of whether the user exists (never reveals user existence)
+6. Returns `:ok` whether or not the user exists, so the response body does not
+   reveal account existence — see "Request timing and account enumeration" above
 
 **Sign-in flow:**
 

--- a/documentation/tutorials/password.md
+++ b/documentation/tutorials/password.md
@@ -64,3 +64,20 @@ end
 
 Now we have enough in place to register and sign-in users using the
 `AshAuthentication.Strategy` protocol.
+
+## Reset request timing and account enumeration
+
+When you configure `resettable` with a sender, the strategy adds a reset request
+action. That action returns `:ok` whether or not the identity matches a user, so
+the response body does not reveal which accounts exist. The response *time* does.
+On a match, the action mints a reset token and then calls your sender inline. On a
+miss, it returns straight away. There is no registration option here, so the miss
+path always short-circuits. A synchronous SMTP or HTTP-API send adds tens to
+hundreds of milliseconds, which is enough to tell the two paths apart.
+
+An asynchronous sender closes that gap. A sender that enqueues a job and returns
+`:ok` immediately keeps delivery latency off both paths. The difference then falls
+to one JWT signing operation, about 27 microseconds. Neither path writes to the
+database unless you enable `store_all_tokens?`. At that size the difference is not
+measurable across a network. See `AshAuthentication.Sender`, which recommends the
+same pattern for retries.


### PR DESCRIPTION
## What this documents

The magic link, password reset and OTP request actions all return a uniform `:ok`
whether or not the identity matches a user. The response *body* therefore does not
reveal which accounts exist. The response *time* is not uniform.

On a match the action mints a token and calls the configured sender inline. On a
miss it does neither. A synchronous SMTP or HTTP-API send takes tens to hundreds of
milliseconds, so the two paths are easy to separate. Account enumeration by timing
is the result.

The library's own contribution to that difference is small. Measured hit-versus-miss
for magic link is about 27 microseconds — one JWT signing operation. There is no
database write on either path by default, because `store_all_tokens?` defaults to
`false`. At that size the difference is not measurable across a network.

## Recommended mitigation

An asynchronous sender. A sender that enqueues a job and returns `:ok` immediately
keeps delivery latency off both paths and leaves only the intrinsic difference.
This is not new advice — `AshAuthentication.Sender`'s moduledoc already recommends
the same pattern for retries — so the pages cross-reference it rather than repeating
it.

## Per-strategy notes

- **Magic link** — the difference only arises when `registration_enabled?` is
  `false`. With registration enabled both paths mint a token and call the sender,
  and the measured difference falls to around 3 microseconds.
- **Password reset** — no registration gate, so the miss path always short-circuits.
- **OTP** — worst case. `Otp.generate_otp_token_for/5` and
  `generate_otp_token_for_identity/5` store the token unconditionally, regardless of
  `store_all_tokens?`, so the match path also performs a database insert the miss
  path does not. Left unquantified, as it was not measured directly.

The OTP page's request-flow step 6 previously read "never reveals user existence".
That is reworded to say the response body does not reveal it, so the page does not
contradict the new section.

## Why documentation rather than a code fix

A code fix was considered and rejected. Moving sends off the request path would
reverse the deliberate breaking change that made sender failures propagate to the
caller. It would also still leave the intrinsic difference, which the async-sender
mitigation already reduces to the same floor. The cost exceeds the size of the leak.

## Follow-up

A backport to `stable-4.0` follows separately. It covers `magic-links.md` and
`password.md` only; `otp.md` does not exist on that branch.

Documentation only. No `.ex` file is touched. `mix check --no-retry` is clean.