### PR TITLE
docs: describe request action timing and account enumeration

### DIFF
--- a/documentation/tutorials/magic-links.md
+++ b/documentation/tutorials/magic-links.md
@@ -112,3 +112,25 @@ end
 
 # ...
 ```
+
+## Request timing and account enumeration
+
+The request action returns `:ok` whether or not the identity matches a user. The
+response body therefore does not reveal which accounts exist. The response *time*
+is a different matter. When the identity matches, the action mints a token and
+calls your sender inline. When it does not match, it does neither. A synchronous
+SMTP or HTTP-API send takes tens to hundreds of milliseconds. That gap is easy to
+measure, so it separates known identities from unknown ones.
+
+The sender is the part you control, and it is the part that leaks. Make it
+asynchronous. Enqueue a job from your `send/3` callback and return `:ok` straight
+away, then deliver the message from the job. That keeps delivery latency off both
+paths. The callback's return value is ignored anyway, so returning early gives up
+nothing — see `AshAuthentication.Sender`. What remains is one JWT signing
+operation, about 27 microseconds. Neither path writes to the database unless you
+enable `store_all_tokens?`. A difference that small is not measurable across a
+network.
+
+This only applies when `registration_enabled?` is `false`, which is the default. With registration
+enabled, both paths mint a token and call the sender. The remaining difference is
+then around 3 microseconds.

--- a/documentation/tutorials/password.md
+++ b/documentation/tutorials/password.md
@@ -64,3 +64,21 @@ end
 
 Now we have enough in place to register and sign-in users using the
 `AshAuthentication.Strategy` protocol.
+
+## Reset request timing and account enumeration
+
+When you configure `resettable` with a sender, the strategy adds a reset request
+action. That action returns `:ok` whether or not the identity matches a user, so
+the response body does not reveal which accounts exist. The response *time* does.
+On a match, the action mints a reset token and then calls your sender inline. On a
+miss, it returns straight away. There is no registration option here, so the miss
+path always short-circuits. A synchronous SMTP or HTTP-API send adds tens to
+hundreds of milliseconds, which is enough to tell the two paths apart.
+
+An asynchronous sender closes that gap. Enqueue a job from your `send/3` callback
+and return `:ok` straight away, then deliver the message from the job. That keeps
+delivery latency off both paths. The callback's return value is ignored anyway, so
+returning early gives up nothing — see `AshAuthentication.Sender`. The difference
+then falls to one JWT signing operation, about 27 microseconds. Neither path
+writes to the database unless you enable `store_all_tokens?`. At that size the
+difference is not measurable across a network.


### PR DESCRIPTION
The 4.x backport of the docs change on `main`.

The magic link and password reset request actions both return `:ok` whether or not the identity matches a user. The response body therefore does not reveal which accounts exist. The response time is not uniform: a match mints a token and calls the sender inline, a miss does neither. This documents that property on each tutorial page and points at an asynchronous sender as the mitigation.

Two differences from the change on `main`:

- The `otp.md` hunks are dropped. The OTP strategy does not exist on this line, so only `magic-links.md` and `password.md` are touched.
- The asynchronous sender recommendation is stated directly instead of cross-referenced. On `main` the `AshAuthentication.Sender` moduledoc recommends a job queue, so that page can defer to it. The moduledoc on this branch predates that guidance and only says that failures are ignored. A cross-reference would send readers to something that is not there. The pages still name `AshAuthentication.Sender` as where senders are documented.

Verified against this branch rather than assumed:

- `store_all_tokens?` still defaults to `false`, so the "no database write on either path by default" statement holds.
- The magic link request action still gates the miss path on `registration_enabled?`, so the timing difference only arises when registration is disabled.
- The password reset preparation has no registration option, so its miss path always short-circuits.
- Both senders' return values are already discarded, so an asynchronous sender gives up no error propagation here.

Documentation only. No code changes.