### PR TITLE
chore(remember_me): set `secure: true` unconditionally on the cookie

### DIFF
--- a/lib/ash_authentication/strategies/remember_me/plug/helpers.ex
+++ b/lib/ash_authentication/strategies/remember_me/plug/helpers.ex
@@ -87,9 +87,9 @@ defmodule AshAuthentication.Strategy.RememberMe.Plug.Helpers do
   @remember_me_cookie_options [
     # cookie is only readable by HTTP/S
     http_only: true,
-    # only send the cookie over HTTPS, except in development
-    # otherwise Safari will block the cookie
-    secure: Mix.env() != :dev,
+    # always marked `Secure`, so browsers only send the cookie over HTTPS
+    # remember-me therefore does not work over plain `http://` in local development
+    secure: true,
     # prevents the cookie from being sent with cross-site requests
     same_site: "Lax"
   ]


### PR DESCRIPTION
## This is not a security fix

A report claimed that `secure: Mix.env() != :dev` yields `secure: false` in `MIX_ENV=dev` deployments. That claim is false.

Mix compiles a dependency with `Mix.env() == :prod`, whatever environment the consuming application builds in. The expression therefore inlined to `secure: true` in **every** consumer build. This was confirmed empirically: real applications that depend on `ash_authentication` from Hex, built under dev, test and prod and as releases, produce a byte-identical compiled module with `secure: true`.

Nothing observable changes for consumers. Please do not read this as a security fix, and do not treat it as advisory-worthy.

## The actual defect is the inverse

Because the conditional is dead for consumers, the Safari development carve-out that the comment promises never engages. In consumer development the cookie always carries `Secure`. Remember-me then fails silently in Safari over `http://localhost`. That is the exact situation the comment claims to avoid.

The code was safe. The comment described behaviour the library does not have.

## The change

Set `secure: true` unconditionally and correct the comment so it describes what the code actually does.

A branch on `Mix.env()` in library code is a documented Elixir anti-pattern, because a library's compile-time environment is not the consumer's. Removing it forecloses this misreading. This was the only occurrence of `Mix.env()` under `lib/`.

This deliberately adds **no** runtime or configuration escape hatch for `secure`. Restoring the Safari carve-out properly would introduce a supported way to disable `Secure` on an authentication cookie. That needs more thought than this change.

## Tests

No new tests. `test/ash_authentication/strategies/remember_me/plug/helpers_test.exs` already asserts `secure: true`, `http_only: true` and `same_site: "Lax"` in three places: `put_remember_me_cookie/3`, `delete_remember_me_cookie/2` and `delete_all_remember_me_cookies/1`.

Worth noting the limit of that existing coverage: the suite runs under `MIX_ENV=test`, so `Mix.env() != :dev` was already `true`. The assertions pinned the flags, but were never sensitive to the `:dev` branch. They are now sensitive to the only value the code can produce.

---

Backport to the `4.x` line. The expression and its surrounding code are identical on both branches.
