### PR TITLE
fix(audit_log): match `Forwarded` parameter names case-insensitively

### DIFF
--- a/lib/ash_authentication/add_ons/audit_log/ip_privacy.ex
+++ b/lib/ash_authentication/add_ons/audit_log/ip_privacy.ex
@@ -115,33 +115,41 @@ defmodule AshAuthentication.AddOn.AuditLog.IpPrivacy do
 
   defp transform_forwarded_header(header, _mode, _opts), do: header
 
+  # RFC 7239 section 4 states that parameter names are case-insensitive, so the
+  # name is downcased before dispatch. The value keeps its case.
+  @forwarded_ip_params ~w[for by]
+  @forwarded_verbatim_params ~w[proto host]
+
   defp transform_forwarded_param(param, mode, opts) do
     param = String.trim(param)
 
     case String.split(param, "=", parts: 2) do
-      ["for", value] ->
-        # Remove quotes and port if present
-        ip =
-          value
-          |> String.trim("\"")
-          |> extract_ip_from_forwarded()
-          |> apply_privacy(mode, opts)
+      [name, value] ->
+        case String.downcase(name) do
+          ip_param when ip_param in @forwarded_ip_params ->
+            transform_forwarded_ip(ip_param, value, mode, opts)
 
-        if ip, do: "for=#{maybe_quote_forwarded(ip)}", else: nil
+          verbatim_param when verbatim_param in @forwarded_verbatim_params ->
+            param
 
-      ["by", value] ->
-        # Remove quotes and port if present
-        ip =
-          value
-          |> String.trim("\"")
-          |> extract_ip_from_forwarded()
-          |> apply_privacy(mode, opts)
-
-        if ip, do: "by=#{maybe_quote_forwarded(ip)}", else: nil
+          _ ->
+            nil
+        end
 
       _ ->
-        param
+        nil
     end
+  end
+
+  defp transform_forwarded_ip(name, value, mode, opts) do
+    # Remove quotes and port if present
+    ip =
+      value
+      |> String.trim("\"")
+      |> extract_ip_from_forwarded()
+      |> apply_privacy(mode, opts)
+
+    if ip, do: "#{name}=#{maybe_quote_forwarded(ip)}", else: nil
   end
 
   defp extract_ip_from_forwarded(value) do

--- a/test/ash_authentication/add_ons/audit_log/ip_privacy_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/ip_privacy_test.exs
@@ -191,6 +191,103 @@ defmodule AshAuthentication.AddOn.AuditLog.IpPrivacyTest do
     end
   end
 
+  describe "apply_to_request/3 forwarded parameter names" do
+    @privacy_modes [
+      {:none, %{}},
+      {:hash, %{}},
+      {:truncate, %{truncation_masks: %{ipv4: 24, ipv6: 48}}},
+      {:exclude, %{}}
+    ]
+
+    test "case variants of `for` and `by` transform like their lowercase equivalents" do
+      for {mode, opts} <- @privacy_modes do
+        expected =
+          IpPrivacy.apply_to_request(
+            %{forwarded: ["for=203.0.113.8;by=198.51.100.4"]},
+            mode,
+            opts
+          )
+
+        for header <- [
+              "For=203.0.113.8;BY=198.51.100.4",
+              "FOR=203.0.113.8;By=198.51.100.4",
+              "fOr=203.0.113.8;bY=198.51.100.4"
+            ] do
+          assert IpPrivacy.apply_to_request(%{forwarded: [header]}, mode, opts) == expected,
+                 "#{header} under #{inspect(mode)}"
+        end
+      end
+    end
+
+    test "case variants of quoted IPv6 `for` transform like their lowercase equivalents" do
+      for {mode, opts} <- @privacy_modes do
+        expected =
+          IpPrivacy.apply_to_request(
+            %{forwarded: ["for=\"[2001:db8::1]:3000\""]},
+            mode,
+            opts
+          )
+
+        assert IpPrivacy.apply_to_request(
+                 %{forwarded: ["For=\"[2001:db8::1]:3000\""]},
+                 mode,
+                 opts
+               ) == expected
+      end
+    end
+
+    test "excludes mixed-case `For` and `BY` when mode is exclude" do
+      request = %{forwarded: ["For=203.0.113.8;Proto=https;BY=198.51.100.4"]}
+
+      assert IpPrivacy.apply_to_request(request, :exclude, %{}).forwarded == ["Proto=https"]
+    end
+
+    test "drops unrecognised parameters" do
+      request = %{
+        forwarded: [
+          "for=203.0.113.8;secret=<script>alert(1)</script>;proto=https",
+          "for=203.0.113.8;no-equals-sign"
+        ]
+      }
+
+      assert IpPrivacy.apply_to_request(request, :none, %{}).forwarded == [
+               "for=203.0.113.8;proto=https",
+               "for=203.0.113.8"
+             ]
+    end
+
+    test "preserves `proto` and `host` values and names unaltered" do
+      request = %{forwarded: ["for=203.0.113.8;Proto=HTTPS;host=Example.COM"]}
+
+      for {mode, opts} <- @privacy_modes do
+        [header] = IpPrivacy.apply_to_request(request, mode, opts).forwarded
+
+        assert String.contains?(header, "Proto=HTTPS")
+        assert String.contains?(header, "host=Example.COM")
+      end
+    end
+
+    test "handles a comma-appended element without leaking either address" do
+      request = %{forwarded: ["For=6.6.6.6, for=203.0.113.8"]}
+
+      assert IpPrivacy.apply_to_request(request, :exclude, %{}).forwarded == [""]
+
+      [hashed] = IpPrivacy.apply_to_request(request, :hash, %{}).forwarded
+      assert String.starts_with?(hashed, "for=hashed:")
+      refute String.contains?(hashed, "6.6.6.6")
+      refute String.contains?(hashed, "203.0.113.8")
+
+      [truncated] =
+        IpPrivacy.apply_to_request(request, :truncate, %{truncation_masks: %{ipv4: 24}}).forwarded
+
+      assert truncated == "for=invalid-ip"
+
+      assert IpPrivacy.apply_to_request(request, :none, %{}).forwarded == [
+               "for=6.6.6.6, for=203.0.113.8"
+             ]
+    end
+  end
+
   describe "hash_ip/1" do
     test "produces consistent hashes" do
       ip = "192.168.1.100"


### PR DESCRIPTION
4.x backport of the `Forwarded` parameter-name fix. `ip_privacy.ex` and its test file are byte-identical between `main` and `stable-4.0`, so the commit cherry-picks cleanly and the diff matches the `main` PR exactly.

## The bug

`AshAuthentication.AddOn.AuditLog.IpPrivacy.transform_forwarded_param/3` matched RFC 7239 parameter names against the literal lowercase strings `for` and `by`. RFC 7239 section 4 states that parameter names are case-insensitive, and the RFC's own examples use `For=`.

So `For=`, `FOR=` and `BY=` fell to the catch-all clause, which returned the parameter byte-for-byte. The configured `ip_privacy_mode` never applied to that field.

Verified end to end: an unauthenticated failed sign-in that carries

```
Forwarded: For=203.0.113.8;Proto=https;BY=198.51.100.4
```

under `ip_privacy_mode :exclude` writes an audit row that holds both addresses verbatim. `remote_ip` and `x_forwarded_for` in the same row are excluded correctly.

The catch-all also passed any unrecognised parameter through verbatim, so arbitrary client-supplied text reached the audit store under every mode.

## The fix

1. Downcase the parameter **name** before the match. The value keeps its case, so `host=Example.COM` and every extension parameter's value stay as received. An audit log must not quietly alter what it records.
2. Allowlist the known parameters. `for` and `by` get the privacy transformation. `proto` and `host` pass through unaltered, which is what the catch-all was really there to protect. Everything else is dropped rather than stored verbatim.

The two `for` and `by` branches were byte-identical, so they collapse into one `transform_forwarded_ip/4` helper.

`apply_privacy/3`, `extract_ip_from_forwarded/1`, `maybe_quote_forwarded/1` and `truncate_ip/2` are unchanged.

## Notes

- `extract_ip_from_forwarded/1` returns text that is not an IP unchanged. `apply_privacy/3` is total over its input: `:exclude` drops the parameter, `:hash` returns a 23-character `hashed:` token, `:truncate` returns `"invalid-ip"`. Only `:none`, the default, stores the value as received. A recognised parameter's value is therefore bounded in every mode that claims to protect it.
- The parser splits on `;` only, never on `,`. A proxy that appends its element to a client-supplied header produces one parameter, `For=6.6.6.6, for=203.0.113.8`. Before this change that whole string was stored verbatim. After it, the name matches `for`, the value fails IP extraction, and the modes bound it as above: dropped under `:exclude`, hashed under `:hash`, `for=invalid-ip` under `:truncate`. A new test pins that shape.
- Nothing in the codebase parses the stored `forwarded` field back. `Plug.Dispatcher` reads the request header, `IpPrivacy` transforms it, and the audit log resource stores it.

## Tests

The existing tests use lowercase parameter names throughout, which is why the suite passed with the bug in place. They are unchanged. Six new tests cover:

- `For=`, `FOR=`, `fOr=`, `BY=`, `By=` and `bY=` transformed identically to their lowercase equivalents, across all four modes, for both bare IPv4 and quoted IPv6-with-port.
- Mixed-case `For` and `BY` excluded under `:exclude`.
- An unrecognised parameter dropped, and a parameter with no `=` dropped.
- `proto` and `host` preserved with their names and values unaltered, including case.
- The comma-appended element above.

Five of the six fail against the unfixed code. The `proto`/`host` test passes before and after; it guards the pass-through.

## Quality gate

`mix check --no-retry` passes apart from two pre-existing failures, both unchanged by this branch:

- `hex_audit` — the LOW `usage_rules` advisory `EEF-CVE-2026-82710` on a dev-only dependency.
- `generate_migrations` — pending codegen left from a dependency bump. Confirmed to fail the same way on a pristine `stable-4.0` checkout.