### PR TITLE
fix(oauth2): mark the provider tokens as sensitive

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.Strategy.OAuth2.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.OAuth2.md
@@ -155,7 +155,7 @@ defmodule MyApp.Accounts.User do
   actions do
     read :sign_in_with_example do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(email == get_path(^arg(:user_info), [:email]))
@@ -184,7 +184,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :email
 

--- a/documentation/tutorials/auth0.md
+++ b/documentation/tutorials/auth0.md
@@ -123,7 +123,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_auth0 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/dynamic-oidc.md
+++ b/documentation/tutorials/dynamic-oidc.md
@@ -117,7 +117,7 @@ collide.
 actions do
   create :register_with_sso do
     argument :user_info, :map, allow_nil?: false
-    argument :oauth_tokens, :map, allow_nil?: false
+    argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
     upsert? true
     upsert_identity :unique_email
 

--- a/documentation/tutorials/github.md
+++ b/documentation/tutorials/github.md
@@ -134,7 +134,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_github do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/google.md
+++ b/documentation/tutorials/google.md
@@ -65,7 +65,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_google do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/microsoft.md
+++ b/documentation/tutorials/microsoft.md
@@ -82,7 +82,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_microsoft do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/okta.md
+++ b/documentation/tutorials/okta.md
@@ -81,7 +81,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_okta do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/slack.md
+++ b/documentation/tutorials/slack.md
@@ -143,7 +143,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_slack do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/lib/ash_authentication/igniter.ex
+++ b/lib/ash_authentication/igniter.ex
@@ -432,7 +432,7 @@ if Code.ensure_loaded?(Igniter) do
         """
         create :register_with_#{strategy_name} do
           argument :user_info, :map, allow_nil?: false
-          argument :oauth_tokens, :map, allow_nil?: false
+          argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
           upsert? true
           upsert_identity :unique_#{identity_field}
 

--- a/lib/ash_authentication/strategies/oauth2.ex
+++ b/lib/ash_authentication/strategies/oauth2.ex
@@ -158,7 +158,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
     actions do
       read :sign_in_with_example do
         argument :user_info, :map, allow_nil?: false
-        argument :oauth_tokens, :map, allow_nil?: false
+        argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
         prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
         filter expr(email == get_path(^arg(:user_info), [:email]))
@@ -187,7 +187,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
     actions do
       create :register_with_oauth2 do
         argument :user_info, :map, allow_nil?: false
-        argument :oauth_tokens, :map, allow_nil?: false
+        argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
         upsert? true
         upsert_identity :email
 

--- a/lib/ash_authentication/strategies/oauth2/transformer.ex
+++ b/lib/ash_authentication/strategies/oauth2/transformer.ex
@@ -88,6 +88,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
          :ok <-
            validate_action_argument_option(action, :oauth_tokens, :type, [Type.Map, :map]),
          :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
+         :ok <- validate_action_argument_option(action, :oauth_tokens, :sensitive?, [true]),
          :ok <- maybe_validate_action_has_token_change(dsl_state, action),
          :ok <- validate_field_in_values(action, :upsert?, [true]),
          :ok <-
@@ -151,6 +152,7 @@ defmodule AshAuthentication.Strategy.OAuth2.Transformer do
          :ok <-
            validate_action_argument_option(action, :oauth_tokens, :type, [Ash.Type.Map, :map]),
          :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
+         :ok <- validate_action_argument_option(action, :oauth_tokens, :sensitive?, [true]),
          :ok <- validate_action_has_preparation(action, OAuth2.SignInPreparation) do
       :ok
     else

--- a/lib/ash_authentication/user_identity/transformer.ex
+++ b/lib/ash_authentication/user_identity/transformer.ex
@@ -75,7 +75,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, access_token, Type.String,
              allow_nil?: true,
-             writable?: true
+             writable?: true,
+             sensitive?: true
            ),
          :ok <- validate_token_field(dsl_state, access_token),
          {:ok, dsl_state} <-
@@ -87,7 +88,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, refresh_token, Type.String,
              allow_nil?: true,
-             writable?: true
+             writable?: true,
+             sensitive?: true
            ),
          :ok <- validate_token_field(dsl_state, refresh_token),
          {:ok, user_resource} <- UserIdentity.Info.user_identity_user_resource(dsl_state),
@@ -164,7 +166,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          {:ok, attribute} <- find_attribute(dsl_state, field_name),
          :ok <- validate_attribute_option(attribute, resource, :type, [Type.String, :string]),
          :ok <- validate_attribute_option(attribute, resource, :allow_nil?, [true]),
-         :ok <- validate_attribute_option(attribute, resource, :writable?, [true]) do
+         :ok <- validate_attribute_option(attribute, resource, :writable?, [true]),
+         :ok <- validate_attribute_option(attribute, resource, :sensitive?, [true]) do
       :ok
     else
       {:error, reason} -> {:error, reason}
@@ -244,7 +247,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
         Transformer.build_entity!(Resource.Dsl, [:actions, :create], :argument,
           name: :oauth_tokens,
           type: Type.Map,
-          allow_nil?: false
+          allow_nil?: false,
+          sensitive?: true
         ),
         Transformer.build_entity!(Resource.Dsl, [:actions, :create], :argument,
           name: user_id,
@@ -280,6 +284,7 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          :ok <- validate_action_argument_option(action, :user_info, :allow_nil?, [false]),
          :ok <- validate_action_argument_option(action, :oauth_tokens, :type, [:map, Type.Map]),
          :ok <- validate_action_argument_option(action, :oauth_tokens, :allow_nil?, [false]),
+         :ok <- validate_action_argument_option(action, :oauth_tokens, :sensitive?, [true]),
          :ok <- validate_action_has_change(action, UserIdentity.UpsertIdentityChange),
          :ok <- validate_field_in_values(action, :type, [:create]),
          :ok <- validate_field_in_values(action, :upsert?, [true]),

--- a/test/ash_authentication/add_ons/audit_log/oauth_tokens_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/oauth_tokens_test.exs
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.AddOn.AuditLog.OAuthTokensTest do
+  @moduledoc """
+  The audit log persists any action field which is public and not sensitive.
+
+  An OAuth2 register action carries the provider's token response in its
+  `oauth_tokens` argument, so the argument must be sensitive or the audit table
+  keeps a plaintext copy of every access and refresh token.
+  """
+  use DataCase, async: false
+
+  alias AshAuthentication.{AddOn.AuditLog.Auditor, AuditLogResource.Batcher}
+  alias Spark.Dsl.Extension
+
+  @access_token "audit-access-token-value"
+  @refresh_token "audit-refresh-token-value"
+
+  setup do
+    start_supervised!({Batcher, otp_app: :ash_authentication})
+    :ok
+  end
+
+  test "the `oauth_tokens` argument is not in the persisted field list" do
+    arguments =
+      Extension.get_persisted(
+        Example.UserWithOAuthAuditLog,
+        {:audit_log, :audit_log, :register_with_oauth2, :arguments}
+      )
+
+    assert :register_with_oauth2 in Auditor.get_tracked_actions(
+             Example.UserWithOAuthAuditLog,
+             :audit_log
+           )
+
+    assert :user_info in arguments
+    refute :oauth_tokens in arguments
+  end
+
+  test "an OAuth2 registration does not write the provider tokens to the audit log" do
+    uid = System.unique_integer([:positive])
+
+    params = %{
+      "user_info" => %{"sub" => "uid-#{uid}", "email" => "audit-#{uid}@example.com"},
+      "oauth_tokens" => %{
+        "access_token" => @access_token,
+        "refresh_token" => @refresh_token
+      }
+    }
+
+    strategy = AshAuthentication.Info.strategy!(Example.UserWithOAuthAuditLog, :oauth2)
+    {:ok, _user} = AshAuthentication.Strategy.action(strategy, :register, params, [])
+
+    Batcher.flush()
+
+    assert [log] =
+             Example.AuditLog
+             |> Ash.read!()
+             |> Enum.filter(&(&1.action_name == :register_with_oauth2))
+
+    refute inspect(log.extra_data) =~ @access_token
+    refute inspect(log.extra_data) =~ @refresh_token
+    refute Map.has_key?(log.extra_data["params"], "oauth_tokens")
+  end
+end

--- a/test/ash_authentication/strategies/oauth2/transformer_test.exs
+++ b/test/ash_authentication/strategies/oauth2/transformer_test.exs
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.Strategy.OAuth2.TransformerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Spark.Error.DslError
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  test "a register action whose `oauth_tokens` argument is not sensitive is rejected" do
+    assert_raise DslError, ~r/`:oauth_tokens`.*`:sensitive\?` set to `true`/s, fn ->
+      defmodule PlaintextRegisterUser do
+        @moduledoc false
+        use Ash.Resource,
+          domain: AshAuthentication.Strategy.OAuth2.TransformerTest.Domain,
+          extensions: [AshAuthentication],
+          data_layer: Ash.DataLayer.Ets,
+          validate_domain_inclusion?: false
+
+        attributes do
+          uuid_primary_key :id
+          attribute :email, :ci_string, allow_nil?: false, public?: true
+        end
+
+        identities do
+          identity :unique_email, [:email]
+        end
+
+        actions do
+          defaults [:read]
+
+          create :register_with_oauth2 do
+            argument :user_info, :map, allow_nil?: false
+            argument :oauth_tokens, :map, allow_nil?: false
+            upsert? true
+            upsert_identity :unique_email
+            change AshAuthentication.GenerateTokenChange
+          end
+        end
+
+        authentication do
+          tokens do
+            enabled? true
+            token_resource __MODULE__.Token
+            signing_secret fn _, _ -> {:ok, "test_secret_that_is_at_least_32_bytes_long"} end
+          end
+
+          strategies do
+            oauth2 :oauth2 do
+              client_id fn _, _ -> {:ok, "client_id"} end
+              client_secret fn _, _ -> {:ok, "client_secret"} end
+              redirect_uri fn _, _ -> {:ok, "https://example.com"} end
+              base_url fn _, _ -> {:ok, "https://example.com"} end
+              authorize_url fn _, _ -> {:ok, "https://example.com/authorize"} end
+              token_url fn _, _ -> {:ok, "https://example.com/token"} end
+              user_url fn _, _ -> {:ok, "https://example.com/userinfo"} end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  test "a sign-in action whose `oauth_tokens` argument is not sensitive is rejected" do
+    assert_raise DslError, ~r/`:oauth_tokens`.*`:sensitive\?` set to `true`/s, fn ->
+      defmodule PlaintextSignInUser do
+        @moduledoc false
+        use Ash.Resource,
+          domain: AshAuthentication.Strategy.OAuth2.TransformerTest.Domain,
+          extensions: [AshAuthentication],
+          data_layer: Ash.DataLayer.Ets,
+          validate_domain_inclusion?: false
+
+        attributes do
+          uuid_primary_key :id
+          attribute :email, :ci_string, allow_nil?: false, public?: true
+        end
+
+        identities do
+          identity :unique_email, [:email]
+        end
+
+        actions do
+          defaults [:read]
+
+          read :sign_in_with_oauth2 do
+            argument :user_info, :map, allow_nil?: false
+            argument :oauth_tokens, :map, allow_nil?: false
+            prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
+          end
+        end
+
+        authentication do
+          tokens do
+            enabled? true
+            token_resource __MODULE__.Token
+            signing_secret fn _, _ -> {:ok, "test_secret_that_is_at_least_32_bytes_long"} end
+          end
+
+          strategies do
+            oauth2 :oauth2 do
+              client_id fn _, _ -> {:ok, "client_id"} end
+              client_secret fn _, _ -> {:ok, "client_secret"} end
+              redirect_uri fn _, _ -> {:ok, "https://example.com"} end
+              base_url fn _, _ -> {:ok, "https://example.com"} end
+              authorize_url fn _, _ -> {:ok, "https://example.com/authorize"} end
+              token_url fn _, _ -> {:ok, "https://example.com/token"} end
+              user_url fn _, _ -> {:ok, "https://example.com/userinfo"} end
+              registration_enabled? false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/ash_authentication/user_identity/transformer_test.exs
+++ b/test/ash_authentication/user_identity/transformer_test.exs
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.UserIdentity.TransformerTest do
+  @moduledoc false
+  use DataCase, async: true
+
+  alias Ash.Resource.Info
+  alias Spark.Error.DslError
+  require Ash.Query
+
+  describe "token fields" do
+    test "the transformer marks the token attributes as sensitive" do
+      for field <- [:access_token, :refresh_token] do
+        assert Info.attribute(Example.UserIdentity, field).sensitive?
+      end
+    end
+
+    test "a hand-written token attribute which is not sensitive is rejected" do
+      assert_raise DslError, ~r/`:sensitive\?` set to `true`/, fn ->
+        defmodule PlaintextIdentity do
+          @moduledoc false
+          use Ash.Resource,
+            data_layer: Ash.DataLayer.Ets,
+            domain: Example,
+            extensions: [AshAuthentication.UserIdentity],
+            validate_domain_inclusion?: false
+
+          attributes do
+            attribute :access_token, :string, allow_nil?: true, writable?: true
+          end
+
+          user_identity do
+            user_resource Example.User
+          end
+        end
+      end
+    end
+  end
+
+  describe "the upsert action" do
+    test "the transformer marks the `oauth_tokens` argument as sensitive" do
+      argument =
+        Example.UserIdentity
+        |> Info.action(:upsert)
+        |> Map.fetch!(:arguments)
+        |> Enum.find(&(&1.name == :oauth_tokens))
+
+      assert argument.sensitive?
+    end
+  end
+
+  describe "reading the tokens back" do
+    setup do
+      user = build_user()
+
+      identity =
+        Example.UserIdentity
+        |> Ash.Changeset.for_create(:upsert, %{
+          strategy: "oauth2",
+          user_id: user.id,
+          user_info: %{"sub" => "uid-#{System.unique_integer([:positive])}"},
+          oauth_tokens: %{
+            "access_token" => "access-token-value",
+            "refresh_token" => "refresh-token-value"
+          }
+        })
+        |> Ash.create!()
+
+      {:ok, identity: identity}
+    end
+
+    test "the provider tokens remain readable for API calls", %{identity: identity} do
+      assert identity.access_token == "access-token-value"
+      assert identity.refresh_token == "refresh-token-value"
+
+      reloaded = Ash.get!(Example.UserIdentity, identity.id)
+      assert reloaded.access_token == "access-token-value"
+
+      selected =
+        Example.UserIdentity
+        |> Ash.Query.select([:id, :access_token])
+        |> Ash.Query.filter(access_token == "access-token-value")
+        |> Ash.read!()
+
+      assert [%{access_token: "access-token-value"}] = selected
+    end
+
+    test "the tokens do not appear in an inspect of the record", %{identity: identity} do
+      output = inspect(identity)
+
+      refute output =~ "access-token-value"
+      refute output =~ "refresh-token-value"
+    end
+  end
+end

--- a/test/ash_authentication_test.exs
+++ b/test/ash_authentication_test.exs
@@ -19,6 +19,7 @@ defmodule AshAuthenticationTest do
                Example.UserWithExplicitIncludes,
                Example.UserWithExtraClaims,
                Example.UserWithFailingSender,
+               Example.UserWithOAuthAuditLog,
                Example.UserWithOtp,
                Example.UserWithRecoveryCodes,
                Example.UserWithRegisterOtp,

--- a/test/support/example.ex
+++ b/test/support/example.ex
@@ -19,6 +19,7 @@ defmodule Example do
     resource Example.UserWithEmptyIncludes
     resource Example.UserWithExcludedActions
     resource Example.UserWithExcludedStrategies
+    resource Example.UserWithOAuthAuditLog
     resource Example.UserWithOtp
     resource Example.UserWithRegisterOtp
     resource Example.UserWithExplicitIncludes

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -101,7 +101,7 @@ defmodule Example.User do
 
     create :register_with_auth0 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -112,7 +112,7 @@ defmodule Example.User do
 
     create :register_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -123,7 +123,7 @@ defmodule Example.User do
 
     create :register_with_oauth2_confirm_link do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -134,7 +134,7 @@ defmodule Example.User do
 
     create :register_with_oidc do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -145,7 +145,7 @@ defmodule Example.User do
 
     create :register_with_okta do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -159,7 +159,7 @@ defmodule Example.User do
 
     create :register_with_sso do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -170,7 +170,7 @@ defmodule Example.User do
 
     read :sign_in_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(username == get_path(^arg(:user_info), [:nickname]))
@@ -178,7 +178,7 @@ defmodule Example.User do
 
     read :sign_in_with_oauth2_without_identity do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(username == get_path(^arg(:user_info), [:nickname]))
@@ -186,7 +186,7 @@ defmodule Example.User do
 
     create :register_with_github do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -197,7 +197,7 @@ defmodule Example.User do
 
     create :register_with_slack do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 

--- a/test/support/example/user_with_oauth_audit_log.ex
+++ b/test/support/example/user_with_oauth_audit_log.ex
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Example.UserWithOAuthAuditLog do
+  @moduledoc """
+  Test resource which combines an OAuth2 strategy with the audit log add-on.
+
+  The add-on persists any action field which is public and not sensitive, so
+  this resource proves that the `oauth_tokens` argument stays out of the audit
+  log.
+  """
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshAuthentication],
+    domain: Example
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+
+    attribute :email, :ci_string, allow_nil?: false, public?: true
+
+    timestamps()
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+
+    create :register_with_oauth2 do
+      argument :user_info, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
+      upsert? true
+      upsert_identity :unique_email
+
+      change AshAuthentication.GenerateTokenChange
+
+      change {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes, fields: [email: :email]}
+    end
+  end
+
+  authentication do
+    session_identifier :jti
+
+    tokens do
+      enabled? true
+
+      token_resource Example.Token
+      signing_secret &get_config/2
+    end
+
+    add_ons do
+      audit_log do
+        audit_log_resource(Example.AuditLog)
+      end
+    end
+
+    strategies do
+      oauth2 do
+        client_id &get_config/2
+        redirect_uri &get_config/2
+        client_secret &get_config/2
+        base_url &get_config/2
+        authorize_url &get_config/2
+        token_url &get_config/2
+        user_url &get_config/2
+        warn_on_missing_identity_resource? false
+        trust_email_verified? true
+      end
+    end
+  end
+
+  identities do
+    identity :unique_email, [:email], pre_check_with: Example
+  end
+
+  def get_config(path, _resource) do
+    value =
+      :ash_authentication
+      |> Application.get_all_env()
+      |> get_in(path)
+
+    {:ok, value}
+  end
+end

--- a/test/support/example_multi_tenant/user.ex
+++ b/test/support/example_multi_tenant/user.ex
@@ -58,7 +58,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_auth0 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -69,7 +69,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_oauth2 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -80,7 +80,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_oidc do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -91,7 +91,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_okta do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -106,7 +106,7 @@ defmodule ExampleMultiTenant.User do
 
     read :sign_in_with_oauth2 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       prepare(AshAuthentication.Strategy.OAuth2.SignInPreparation)
 
       filter(expr(username == get_path(^arg(:user_info), [:nickname])))
@@ -114,7 +114,7 @@ defmodule ExampleMultiTenant.User do
 
     read :sign_in_with_oauth2_without_identity do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       prepare(AshAuthentication.Strategy.OAuth2.SignInPreparation)
 
       filter(expr(username == get_path(^arg(:user_info), [:nickname])))
@@ -122,7 +122,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_github do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -133,7 +133,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_slack do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -199,7 +199,7 @@ end
 actions do
   create :register_with_github do
     argument :user_info, :map, allow_nil?: false
-    argument :oauth_tokens, :map, allow_nil?: false
+    argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
     upsert? true
     upsert_identity :unique_email
 
@@ -318,7 +318,7 @@ When new users can register via OAuth2:
 actions do
   create :register_with_github do
     argument :user_info, :map, allow_nil?: false
-    argument :oauth_tokens, :map, allow_nil?: false
+    argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
     upsert? true
     upsert_identity :email
 


### PR DESCRIPTION
`AshAuthentication.UserIdentity` built `access_token` and `refresh_token`
without `sensitive?: true`, and the `oauth_tokens` argument on the OAuth
register, sign-in and identity-upsert actions carried no flag either. The
gap has existed on every release since v0.6.0.

## Impact

Two consequences.

1. The tokens appear in `inspect/1` output, in `MatchError` messages and in
   GenServer crash reports.
2. The audit log add-on decides what is safe to persist with
   `public? && !sensitive?` (`add_ons/audit_log/transformer.ex`,
   `include_in_fields?/2`), and it applies that rule to arguments as well as
   attributes. An application which enables the audit log alongside any OAuth
   strategy therefore wrote the raw access and refresh tokens into its audit
   table on every registration, retained 90 days by default.

The second is the one that matters. It is a plaintext at-rest copy of a live
refresh token in a table built for wide internal consumption. It is
demonstrated end to end by the new
`AshAuthentication.AddOn.AuditLog.OAuthTokensTest`; against unfixed code that
test prints the tokens out of `audit_logs.extra_data.params.oauth_tokens`.

## The change

Where the library builds the fields, it sets the flag:

- `access_token` and `refresh_token` on a `UserIdentity` resource
- the `oauth_tokens` argument on the identity upsert action

Where the application writes them, the transformer asserts the flag, so a
resource which omits it fails to compile:

- `validate_token_field/2` on a hand-written identity resource
- the `oauth_tokens` argument on the strategy's register and sign-in actions

This is the same shape and wording as the fifteen existing
`validate_attribute_option(…, :sensitive?, [true])` and
`validate_action_argument_option(…, :sensitive?, [true])` call sites for
password hashes, reset tokens, remember-me tokens and the token resource.

Generated and documented code emits the flag, so newly installed and newly
pasted actions carry it:

- `AshAuthentication.Igniter.add_oauth_register_action/4`, which the ten
  `ash_authentication.add_strategy.*` OAuth tasks all call
- the `AshAuthentication.Strategy.OAuth2` moduledoc examples, and the DSL
  reference regenerated from them
- the slack, auth0, dynamic-oidc, okta, github, microsoft and google tutorials
- `usage-rules.md`

`documentation/tutorials/get-started.md` already had it; the rest now agree
with it.

## Scope

`user_info` is deliberately left unflagged. It is audit-relevant profile data
rather than a credential, and warning on it would train people to ignore the
warning.

Reading the tokens for provider API calls is unaffected: struct access,
`Ash.get!`, explicit `Ash.Query.select` and filtering on the attribute all
still work, and `select_by_default?` stays true. There is a new test for that.

## Compatibility

The transformer assertions are a compile-time break for an application whose
OAuth actions or hand-written identity resource omit the flag. That is
intended on this line. The `stable-4.0` companion PR ships the same builders
but warns instead of failing, so no 4.x configuration stops compiling.

## Operator note

No code change repairs rows already written. An audit table which predates
this release may still hold raw access and refresh tokens. Purge those rows or
let the default 90-day retention age them out; `log_lifetime :infinity` will
not.

## Gate

`mix check --no-retry` passes apart from the pre-existing `hex_audit`
failure (`usage_rules` / `EEF-CVE-2026-82710`, LOW, dev-only), which is
present on both release lines before this change.
