### PR TITLE
fix(oauth2): mark the provider tokens as sensitive

### DIFF
--- a/documentation/dsls/DSL-AshAuthentication.Strategy.OAuth2.md
+++ b/documentation/dsls/DSL-AshAuthentication.Strategy.OAuth2.md
@@ -155,7 +155,7 @@ defmodule MyApp.Accounts.User do
   actions do
     read :sign_in_with_example do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(email == get_path(^arg(:user_info), [:email]))
@@ -184,7 +184,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :email
 

--- a/documentation/tutorials/auth0.md
+++ b/documentation/tutorials/auth0.md
@@ -157,7 +157,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_auth0 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/github.md
+++ b/documentation/tutorials/github.md
@@ -168,7 +168,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_github do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/google.md
+++ b/documentation/tutorials/google.md
@@ -100,7 +100,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_google do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/documentation/tutorials/slack.md
+++ b/documentation/tutorials/slack.md
@@ -177,7 +177,7 @@ defmodule MyApp.Accounts.User do
   actions do
     create :register_with_slack do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :unique_email
 

--- a/lib/ash_authentication/strategies/oauth2.ex
+++ b/lib/ash_authentication/strategies/oauth2.ex
@@ -158,7 +158,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
     actions do
       read :sign_in_with_example do
         argument :user_info, :map, allow_nil?: false
-        argument :oauth_tokens, :map, allow_nil?: false
+        argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
         prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
         filter expr(email == get_path(^arg(:user_info), [:email]))
@@ -187,7 +187,7 @@ defmodule AshAuthentication.Strategy.OAuth2 do
     actions do
       create :register_with_oauth2 do
         argument :user_info, :map, allow_nil?: false
-        argument :oauth_tokens, :map, allow_nil?: false
+        argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
         upsert? true
         upsert_identity :email
 

--- a/lib/ash_authentication/user_identity/transformer.ex
+++ b/lib/ash_authentication/user_identity/transformer.ex
@@ -75,7 +75,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, access_token, Type.String,
              allow_nil?: true,
-             writable?: true
+             writable?: true,
+             sensitive?: true
            ),
          :ok <- validate_token_field(dsl_state, access_token),
          {:ok, dsl_state} <-
@@ -87,7 +88,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
          {:ok, dsl_state} <-
            maybe_build_attribute(dsl_state, refresh_token, Type.String,
              allow_nil?: true,
-             writable?: true
+             writable?: true,
+             sensitive?: true
            ),
          :ok <- validate_token_field(dsl_state, refresh_token),
          {:ok, user_resource} <- UserIdentity.Info.user_identity_user_resource(dsl_state),
@@ -244,7 +246,8 @@ defmodule AshAuthentication.UserIdentity.Transformer do
         Transformer.build_entity!(Resource.Dsl, [:actions, :create], :argument,
           name: :oauth_tokens,
           type: Type.Map,
-          allow_nil?: false
+          allow_nil?: false,
+          sensitive?: true
         ),
         Transformer.build_entity!(Resource.Dsl, [:actions, :create], :argument,
           name: user_id,

--- a/lib/ash_authentication/user_identity/verifier.ex
+++ b/lib/ash_authentication/user_identity/verifier.ex
@@ -8,7 +8,9 @@ defmodule AshAuthentication.UserIdentity.Verifier do
   """
 
   use Spark.Dsl.Transformer
+  alias Ash.Resource
   alias AshAuthentication.UserIdentity.Info
+  alias Spark.Dsl.Transformer
   import AshAuthentication.Utils
 
   @doc false
@@ -31,8 +33,12 @@ defmodule AshAuthentication.UserIdentity.Verifier do
   @spec transform(map) ::
           :ok | {:ok, map} | {:error, term} | {:warn, map, String.t() | [String.t()]} | :halt
   def transform(dsl_state) do
-    with :ok <- validate_domain_presence(dsl_state) do
-      validate_user_resource(dsl_state)
+    with :ok <- validate_domain_presence(dsl_state),
+         :ok <- validate_user_resource(dsl_state) do
+      case token_sensitivity_warnings(dsl_state) do
+        [] -> :ok
+        warnings -> {:warn, dsl_state, warnings}
+      end
     end
   end
 
@@ -47,4 +53,63 @@ defmodule AshAuthentication.UserIdentity.Verifier do
       assert_resource_has_extension(user_resource, AshAuthentication)
     end
   end
+
+  # The provider's access and refresh tokens are bearer credentials, so they
+  # must be marked `sensitive?: true`. Anything which reads the flag as a
+  # credential classification - the audit log add-on, the `Inspect` protocol -
+  # otherwise treats them as safe to display and to persist. The transformer
+  # sets the flag on the fields it builds; a hand-written resource is only
+  # warned about, because a hard error would break existing applications on a
+  # patch release.
+  defp token_sensitivity_warnings(dsl_state) do
+    with {:ok, access_token} <- Info.user_identity_access_token_attribute_name(dsl_state),
+         {:ok, refresh_token} <- Info.user_identity_refresh_token_attribute_name(dsl_state) do
+      [
+        attribute_sensitivity_warning(dsl_state, access_token),
+        attribute_sensitivity_warning(dsl_state, refresh_token),
+        upsert_argument_sensitivity_warning(dsl_state)
+      ]
+      |> Enum.reject(&is_nil/1)
+    else
+      _ -> []
+    end
+  end
+
+  defp attribute_sensitivity_warning(dsl_state, field_name) do
+    with attribute when is_map(attribute) <- Resource.Info.attribute(dsl_state, field_name),
+         false <- attribute.sensitive? do
+      """
+      The `#{inspect(field_name)}` attribute on `#{inspect(resource(dsl_state))}` is not marked `sensitive?: true`.
+
+      It holds a bearer credential issued by the identity provider. Without the
+      flag the value appears in `inspect/1` output and in crash reports, and the
+      audit log add-on treats it as safe to persist. Add `sensitive?: true` to
+      the attribute. This will become a hard requirement in a future release.
+      """
+    else
+      _ -> nil
+    end
+  end
+
+  defp upsert_argument_sensitivity_warning(dsl_state) do
+    with {:ok, action_name} <- Info.user_identity_upsert_action_name(dsl_state),
+         action when is_map(action) <- Resource.Info.action(dsl_state, action_name),
+         argument when is_map(argument) <-
+           Enum.find(action.arguments, &(&1.name == :oauth_tokens)),
+         false <- argument.sensitive? do
+      """
+      The `:oauth_tokens` argument on the `#{inspect(action_name)}` action of `#{inspect(resource(dsl_state))}` is not marked `sensitive?: true`.
+
+      It carries the identity provider's whole token response, including the
+      access and refresh tokens. Without the flag the audit log add-on records
+      the tokens in plain text and they appear in `inspect/1` output. Add
+      `sensitive?: true` to the argument. This will become a hard requirement in
+      a future release.
+      """
+    else
+      _ -> nil
+    end
+  end
+
+  defp resource(dsl_state), do: Transformer.get_persisted(dsl_state, :module)
 end

--- a/lib/ash_authentication/validations.ex
+++ b/lib/ash_authentication/validations.ex
@@ -223,12 +223,20 @@ defmodule AshAuthentication.Validations do
       (`trust_email_verified?` is `false`) and no confirmation add-on is
       configured. Accounts created via this strategy would carry an unverified
       email address with no way to verify ownership.
+
+    * The `oauth_tokens` argument on the strategy's register or sign-in action
+      is not marked `sensitive?: true`. The argument carries the provider's
+      whole token response, so anything which reads the flag as a credential
+      classification - the audit log add-on, the `Inspect` protocol - treats
+      the access and refresh tokens as safe to display and to persist. This
+      will become a hard requirement in a future release.
   """
   @spec oauth2_strategy_warnings(struct, Dsl.t() | map) :: :ok | {:warn, [String.t()]}
   def oauth2_strategy_warnings(strategy, dsl_state) do
     [
       identity_resource_warning(strategy),
-      email_verification_warning(strategy, dsl_state)
+      email_verification_warning(strategy, dsl_state),
+      oauth_tokens_sensitivity_warning(strategy, dsl_state)
     ]
     |> Enum.reject(&is_nil/1)
     |> case do
@@ -269,6 +277,33 @@ defmodule AshAuthentication.Validations do
   end
 
   defp email_verification_warning(_strategy, _dsl_state), do: nil
+
+  defp oauth_tokens_sensitivity_warning(strategy, dsl_state) do
+    action_name =
+      if strategy.registration_enabled?,
+        do: strategy.register_action_name,
+        else: strategy.sign_in_action_name
+
+    with action when is_map(action) <- Ash.Resource.Info.action(dsl_state, action_name),
+         argument when is_map(argument) <-
+           Enum.find(action.arguments, &(&1.name == :oauth_tokens)),
+         false <- argument.sensitive? do
+      """
+      The `:oauth_tokens` argument on the `#{inspect(action_name)}` action of `#{inspect(strategy.resource)}` is not marked `sensitive?: true`.
+
+      It carries the identity provider's whole token response, including the
+      access and refresh tokens. Without the flag the audit log add-on records
+      the tokens in plain text and they appear in `inspect/1` output. Add
+      `sensitive?: true` to the argument:
+
+          argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
+
+      This will become a hard requirement in a future release.
+      """
+    else
+      _ -> nil
+    end
+  end
 
   defp has_confirmation_add_on?(dsl_state) do
     dsl_state

--- a/test/ash_authentication/add_ons/audit_log/oauth_tokens_test.exs
+++ b/test/ash_authentication/add_ons/audit_log/oauth_tokens_test.exs
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.AddOn.AuditLog.OAuthTokensTest do
+  @moduledoc """
+  The audit log persists any action field which is public and not sensitive.
+
+  An OAuth2 register action carries the provider's token response in its
+  `oauth_tokens` argument, so the argument must be sensitive or the audit table
+  keeps a plaintext copy of every access and refresh token.
+  """
+  use DataCase, async: false
+
+  alias AshAuthentication.{AddOn.AuditLog.Auditor, AuditLogResource.Batcher}
+  alias Spark.Dsl.Extension
+
+  @access_token "audit-access-token-value"
+  @refresh_token "audit-refresh-token-value"
+
+  setup do
+    start_supervised!({Batcher, otp_app: :ash_authentication})
+    :ok
+  end
+
+  test "the `oauth_tokens` argument is not in the persisted field list" do
+    arguments =
+      Extension.get_persisted(
+        Example.UserWithOAuthAuditLog,
+        {:audit_log, :audit_log, :register_with_oauth2, :arguments}
+      )
+
+    assert :register_with_oauth2 in Auditor.get_tracked_actions(
+             Example.UserWithOAuthAuditLog,
+             :audit_log
+           )
+
+    assert :user_info in arguments
+    refute :oauth_tokens in arguments
+  end
+
+  test "an OAuth2 registration does not write the provider tokens to the audit log" do
+    uid = System.unique_integer([:positive])
+
+    params = %{
+      "user_info" => %{"sub" => "uid-#{uid}", "email" => "audit-#{uid}@example.com"},
+      "oauth_tokens" => %{
+        "access_token" => @access_token,
+        "refresh_token" => @refresh_token
+      }
+    }
+
+    strategy = AshAuthentication.Info.strategy!(Example.UserWithOAuthAuditLog, :oauth2)
+    {:ok, _user} = AshAuthentication.Strategy.action(strategy, :register, params, [])
+
+    Batcher.flush()
+
+    assert [log] =
+             Example.AuditLog
+             |> Ash.read!()
+             |> Enum.filter(&(&1.action_name == :register_with_oauth2))
+
+    refute inspect(log.extra_data) =~ @access_token
+    refute inspect(log.extra_data) =~ @refresh_token
+    refute Map.has_key?(log.extra_data["params"], "oauth_tokens")
+  end
+end

--- a/test/ash_authentication/strategies/oauth2/verifier_test.exs
+++ b/test/ash_authentication/strategies/oauth2/verifier_test.exs
@@ -142,4 +142,67 @@ defmodule AshAuthentication.Strategy.OAuth2.VerifierTest do
     assert error.message =~ "confirmation"
     assert error.message =~ "on_untrusted_email_match"
   end
+
+  test "a register action whose `oauth_tokens` argument is not sensitive warns but still compiles" do
+    warnings =
+      dsl_warnings do
+        defmodule PlaintextTokensUser do
+          @moduledoc false
+          use Ash.Resource,
+            domain: AshAuthentication.Strategy.OAuth2.VerifierTest.Domain,
+            extensions: [AshAuthentication],
+            data_layer: Ash.DataLayer.Ets,
+            validate_domain_inclusion?: false
+
+          attributes do
+            uuid_primary_key :id
+            attribute :email, :ci_string, allow_nil?: false, public?: true
+          end
+
+          identities do
+            identity :unique_email, [:email]
+          end
+
+          actions do
+            defaults [:read]
+
+            create :register_with_oauth2 do
+              argument :user_info, :map, allow_nil?: false
+              argument :oauth_tokens, :map, allow_nil?: false
+              upsert? true
+              upsert_identity :unique_email
+              change AshAuthentication.GenerateTokenChange
+            end
+          end
+
+          authentication do
+            tokens do
+              enabled? true
+              token_resource __MODULE__.Token
+              signing_secret fn _, _ -> {:ok, "test_secret_that_is_at_least_32_bytes_long"} end
+            end
+
+            strategies do
+              oauth2 :oauth2 do
+                client_id fn _, _ -> {:ok, "client_id"} end
+                client_secret fn _, _ -> {:ok, "client_secret"} end
+                redirect_uri fn _, _ -> {:ok, "https://example.com"} end
+                base_url fn _, _ -> {:ok, "https://example.com"} end
+                authorize_url fn _, _ -> {:ok, "https://example.com/authorize"} end
+                token_url fn _, _ -> {:ok, "https://example.com/token"} end
+                user_url fn _, _ -> {:ok, "https://example.com/userinfo"} end
+              end
+            end
+          end
+        end
+      end
+
+    messages =
+      Enum.flat_map(warnings, fn {_module, payloads} ->
+        Enum.map(payloads, fn {message, _location} -> message end)
+      end)
+
+    assert Enum.any?(messages, &(&1 =~ "`:oauth_tokens` argument"))
+    assert Enum.any?(messages, &(&1 =~ "sensitive?: true"))
+  end
 end

--- a/test/ash_authentication/user_identity/transformer_test.exs
+++ b/test/ash_authentication/user_identity/transformer_test.exs
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.UserIdentity.TransformerTest do
+  @moduledoc false
+  use DataCase, async: true
+
+  import ExUnit.CaptureIO
+  alias Ash.Resource.Info
+  require Ash.Query
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      allow_unregistered? true
+    end
+  end
+
+  describe "token fields" do
+    test "the transformer marks the token attributes as sensitive" do
+      for field <- [:access_token, :refresh_token] do
+        assert Info.attribute(Example.UserIdentity, field).sensitive?
+      end
+    end
+
+    test "a hand-written token attribute which is not sensitive warns but still compiles" do
+      output =
+        capture_io(:stderr, fn ->
+          defmodule PlaintextIdentity do
+            @moduledoc false
+            use Ash.Resource,
+              data_layer: Ash.DataLayer.Ets,
+              domain: AshAuthentication.UserIdentity.TransformerTest.Domain,
+              extensions: [AshAuthentication.UserIdentity],
+              validate_domain_inclusion?: false
+
+            attributes do
+              attribute :access_token, :string, allow_nil?: true, writable?: true
+            end
+
+            user_identity do
+              user_resource Example.User
+            end
+
+            identities do
+              identity :unique_on_strategy_and_uid, [:uid, :strategy],
+                pre_check_with: AshAuthentication.UserIdentity.TransformerTest.Domain
+            end
+          end
+        end)
+
+      assert output =~ "`:access_token` attribute"
+      assert output =~ "sensitive?: true"
+
+      resource = Module.concat(__MODULE__, PlaintextIdentity)
+
+      refute Info.attribute(resource, :access_token).sensitive?
+      assert Info.attribute(resource, :refresh_token).sensitive?
+    end
+  end
+
+  describe "the upsert action" do
+    test "the transformer marks the `oauth_tokens` argument as sensitive" do
+      argument =
+        Example.UserIdentity
+        |> Info.action(:upsert)
+        |> Map.fetch!(:arguments)
+        |> Enum.find(&(&1.name == :oauth_tokens))
+
+      assert argument.sensitive?
+    end
+  end
+
+  describe "reading the tokens back" do
+    setup do
+      user = build_user()
+
+      identity =
+        Example.UserIdentity
+        |> Ash.Changeset.for_create(:upsert, %{
+          strategy: "oauth2",
+          user_id: user.id,
+          user_info: %{"sub" => "uid-#{System.unique_integer([:positive])}"},
+          oauth_tokens: %{
+            "access_token" => "access-token-value",
+            "refresh_token" => "refresh-token-value"
+          }
+        })
+        |> Ash.create!()
+
+      {:ok, identity: identity}
+    end
+
+    test "the provider tokens remain readable for API calls", %{identity: identity} do
+      assert identity.access_token == "access-token-value"
+      assert identity.refresh_token == "refresh-token-value"
+
+      reloaded = Ash.get!(Example.UserIdentity, identity.id)
+      assert reloaded.access_token == "access-token-value"
+
+      selected =
+        Example.UserIdentity
+        |> Ash.Query.select([:id, :access_token])
+        |> Ash.Query.filter(access_token == "access-token-value")
+        |> Ash.read!()
+
+      assert [%{access_token: "access-token-value"}] = selected
+    end
+
+    test "the tokens do not appear in an inspect of the record", %{identity: identity} do
+      output = inspect(identity)
+
+      refute output =~ "access-token-value"
+      refute output =~ "refresh-token-value"
+    end
+  end
+end

--- a/test/ash_authentication_test.exs
+++ b/test/ash_authentication_test.exs
@@ -21,6 +21,7 @@ defmodule AshAuthenticationTest do
                Example.UserWithSelectiveStrategyIncludes,
                Example.UserWithTokenRequired,
                Example.UserWithRememberMe,
+               Example.UserWithOAuthAuditLog,
                Example.UserWithRegisterMagicLink,
                Example.UserWithWildcardAndExclusions,
                ExampleMultiTenant.User,

--- a/test/support/example.ex
+++ b/test/support/example.ex
@@ -12,12 +12,14 @@ defmodule Example do
     resource Example.Token
     resource Example.TokenWithCustomCreateTimestamp
     resource Example.User
+    resource Example.OAuthAuditLogUserIdentity
     resource Example.UserIdentity
     resource Example.UserWithAuditLog
     resource Example.UserWithEmptyIncludes
     resource Example.UserWithExcludedActions
     resource Example.UserWithExcludedStrategies
     resource Example.UserWithExplicitIncludes
+    resource Example.UserWithOAuthAuditLog
     resource Example.UserWithRegisterMagicLink
     resource Example.UserWithRememberMe
     resource Example.UserWithRenamedAuditLog

--- a/test/support/example/oauth_audit_log_email_change.ex
+++ b/test/support/example/oauth_audit_log_email_change.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Example.OAuthAuditLogEmailChange do
+  @moduledoc false
+  use Ash.Resource.Change
+  alias Ash.{Changeset, Resource.Change}
+
+  @doc false
+  @impl true
+  @spec change(Changeset.t(), keyword, Change.context()) :: Changeset.t()
+  def change(changeset, _opts, _context) do
+    user_info = Changeset.get_argument(changeset, :user_info)
+
+    Changeset.change_attribute(changeset, :email, user_info["email"])
+  end
+end

--- a/test/support/example/oauth_audit_log_user_identity.ex
+++ b/test/support/example/oauth_audit_log_user_identity.ex
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Example.OAuthAuditLogUserIdentity do
+  @moduledoc """
+  Identity resource for `Example.UserWithOAuthAuditLog`.
+  """
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshAuthentication.UserIdentity],
+    domain: Example
+
+  user_identity do
+    user_resource(Example.UserWithOAuthAuditLog)
+  end
+
+  identities do
+    identity :unique_on_strategy_and_uid, [:uid, :strategy], pre_check_with: Example
+  end
+end

--- a/test/support/example/user.ex
+++ b/test/support/example/user.ex
@@ -101,7 +101,7 @@ defmodule Example.User do
 
     create :register_with_auth0 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -112,7 +112,7 @@ defmodule Example.User do
 
     create :register_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -123,7 +123,7 @@ defmodule Example.User do
 
     create :register_with_oauth2_confirm_link do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -134,7 +134,7 @@ defmodule Example.User do
 
     create :register_with_oidc do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -145,7 +145,7 @@ defmodule Example.User do
 
     read :sign_in_with_oauth2 do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(username == get_path(^arg(:user_info), [:nickname]))
@@ -153,7 +153,7 @@ defmodule Example.User do
 
     read :sign_in_with_oauth2_without_identity do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       prepare AshAuthentication.Strategy.OAuth2.SignInPreparation
 
       filter expr(username == get_path(^arg(:user_info), [:nickname]))
@@ -161,7 +161,7 @@ defmodule Example.User do
 
     create :register_with_github do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 
@@ -172,7 +172,7 @@ defmodule Example.User do
 
     create :register_with_slack do
       argument :user_info, :map, allow_nil?: false
-      argument :oauth_tokens, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
       upsert? true
       upsert_identity :username
 

--- a/test/support/example/user_with_oauth_audit_log.ex
+++ b/test/support/example/user_with_oauth_audit_log.ex
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Example.UserWithOAuthAuditLog do
+  @moduledoc """
+  Test resource which combines an OAuth2 strategy with the audit log add-on.
+
+  The add-on persists any action field which is public and not sensitive, so
+  this resource proves that the `oauth_tokens` argument stays out of the audit
+  log.
+  """
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshAuthentication],
+    domain: Example
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+
+    attribute :email, :ci_string, allow_nil?: false, public?: true
+
+    timestamps()
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+
+    create :register_with_oauth2 do
+      argument :user_info, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
+      upsert? true
+      upsert_identity :unique_email
+
+      change AshAuthentication.GenerateTokenChange
+      change AshAuthentication.Strategy.OAuth2.IdentityChange
+      change Example.OAuthAuditLogEmailChange
+    end
+  end
+
+  authentication do
+    session_identifier :jti
+
+    tokens do
+      enabled? true
+
+      token_resource Example.Token
+      signing_secret &get_config/2
+    end
+
+    add_ons do
+      audit_log do
+        audit_log_resource(Example.AuditLog)
+      end
+    end
+
+    strategies do
+      oauth2 do
+        client_id &get_config/2
+        redirect_uri &get_config/2
+        client_secret &get_config/2
+        base_url &get_config/2
+        authorize_url &get_config/2
+        token_url &get_config/2
+        user_url &get_config/2
+        identity_resource Example.OAuthAuditLogUserIdentity
+        trust_email_verified? true
+      end
+    end
+  end
+
+  identities do
+    identity :unique_email, [:email], pre_check_with: Example
+  end
+
+  def get_config(path, _resource) do
+    value =
+      :ash_authentication
+      |> Application.get_all_env()
+      |> get_in(path)
+
+    {:ok, value}
+  end
+end

--- a/test/support/example_multi_tenant/user.ex
+++ b/test/support/example_multi_tenant/user.ex
@@ -58,7 +58,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_auth0 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -69,7 +69,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_oauth2 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -80,7 +80,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_oidc do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -91,7 +91,7 @@ defmodule ExampleMultiTenant.User do
 
     read :sign_in_with_oauth2 do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       prepare(AshAuthentication.Strategy.OAuth2.SignInPreparation)
 
       filter(expr(username == get_path(^arg(:user_info), [:nickname])))
@@ -99,7 +99,7 @@ defmodule ExampleMultiTenant.User do
 
     read :sign_in_with_oauth2_without_identity do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       prepare(AshAuthentication.Strategy.OAuth2.SignInPreparation)
 
       filter(expr(username == get_path(^arg(:user_info), [:nickname])))
@@ -107,7 +107,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_github do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 
@@ -118,7 +118,7 @@ defmodule ExampleMultiTenant.User do
 
     create :register_with_slack do
       argument(:user_info, :map, allow_nil?: false)
-      argument(:oauth_tokens, :map, allow_nil?: false)
+      argument(:oauth_tokens, :map, allow_nil?: false, sensitive?: true)
       upsert?(true)
       upsert_identity(:username)
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -198,7 +198,7 @@ end
 actions do
   create :register_with_github do
     argument :user_info, :map, allow_nil?: false
-    argument :oauth_tokens, :map, allow_nil?: false
+    argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
     upsert? true
     upsert_identity :unique_email
 
@@ -320,7 +320,7 @@ When new users can register via OAuth2:
 actions do
   create :register_with_github do
     argument :user_info, :map, allow_nil?: false
-    argument :oauth_tokens, :map, allow_nil?: false
+    argument :oauth_tokens, :map, allow_nil?: false, sensitive?: true
     upsert? true
     upsert_identity :email
 


### PR DESCRIPTION
The `stable-4.0` companion to #1220.

`AshAuthentication.UserIdentity` built `access_token` and `refresh_token`
without `sensitive?: true`, and the `oauth_tokens` argument on the OAuth
register, sign-in and identity-upsert actions carried no flag either. The
gap has existed on every release since v0.6.0.

## Impact

Two consequences.

1. The tokens appear in `inspect/1` output, in `MatchError` messages and in
   GenServer crash reports.
2. The audit log add-on decides what is safe to persist with
   `public? && !sensitive?` (`add_ons/audit_log/transformer.ex`,
   `include_in_fields?/2`), and it applies that rule to arguments as well as
   attributes. An application which enables the audit log alongside any OAuth
   strategy therefore wrote the raw access and refresh tokens into its audit
   table on every registration, retained 90 days by default.

The second is the one that matters. It is a plaintext at-rest copy of a live
refresh token in a table built for wide internal consumption. It is
demonstrated end to end by the new
`AshAuthentication.AddOn.AuditLog.OAuthTokensTest`; against unfixed code that
test prints the tokens out of `audit_logs.extra_data.params.oauth_tokens`.

## The change

Where the library builds the fields, it sets the flag:

- `access_token` and `refresh_token` on a `UserIdentity` resource
- the `oauth_tokens` argument on the identity upsert action

Where the application writes them, it gets a compile-time warning, never an
error, so no existing configuration stops compiling on a patch release:

- `AshAuthentication.UserIdentity.Verifier` warns about a hand-written token
  attribute, or a hand-written upsert action, which omits the flag
- `oauth2_strategy_warnings/2` warns when the strategy's register or sign-in
  action omits it, which covers the oauth2, oidc, apple and slack strategies

Both return `{:warn, …}` explicitly. Neither leans on Spark's verify-phase
`catch`, which would make the non-breakingness a property of Spark internals.

Documented code emits the flag, so newly pasted actions carry it:

- the `AshAuthentication.Strategy.OAuth2` moduledoc examples, and the DSL
  reference regenerated from them
- the slack, auth0, github and google tutorials
- `usage-rules.md`

`documentation/tutorials/get-started.md` already had it; the rest now agree
with it.

There is no OAuth generator on this line, so nothing to change there.

## Scope

`user_info` is deliberately left unflagged. It is audit-relevant profile data
rather than a credential, and warning on it would train people to ignore the
warning.

Reading the tokens for provider API calls is unaffected: struct access,
`Ash.get!`, explicit `Ash.Query.select` and filtering on the attribute all
still work, and `select_by_default?` stays true. There is a new test for that.

## Difference from `main`

On `main` the two hand-written checks are transformer assertions and do fail
the compile. Here they warn. The builders are identical on both lines.

## Operator note

No code change repairs rows already written. An audit table which predates
this release may still hold raw access and refresh tokens. Purge those rows or
let the default 90-day retention age them out; `log_lifetime :infinity` will
not.

## Gate

`mix check --no-retry` passes apart from the pre-existing `hex_audit`
failure (`usage_rules` / `EEF-CVE-2026-82710`, LOW, dev-only), which is
present on both release lines before this change. `generate_migrations`
passes.
