### PR TITLE
fix(oauth2): check every upsert field in the anti-hijacking verifier

### DIFF
--- a/lib/ash_authentication/strategies/oauth2/verifier.ex
+++ b/lib/ash_authentication/strategies/oauth2/verifier.ex
@@ -21,10 +21,12 @@ defmodule AshAuthentication.Strategy.OAuth2.Verifier do
          :ok <- validate_secret(strategy, :base_url),
          :ok <- validate_secret(strategy, :token_url),
          :ok <- validate_secret(strategy, :user_url),
-         :ok <- prevent_hijacking(dsl_state, strategy),
          :ok <- validate_confirmation_for_untrusted_match(dsl_state, strategy),
          :ok <- validate_private_key(strategy) do
-      oauth2_strategy_warnings(strategy, dsl_state)
+      merge_warnings([
+        prevent_hijacking(dsl_state, strategy),
+        oauth2_strategy_warnings(strategy, dsl_state)
+      ])
     end
   end
 
@@ -61,41 +63,65 @@ defmodule AshAuthentication.Strategy.OAuth2.Verifier do
   defp prevent_hijacking(_dsl_state, %{registration_enabled?: false}), do: :ok
 
   defp prevent_hijacking(dsl_state, strategy) do
-    case Enum.find(
-           AshAuthentication.Info.authentication_strategies(dsl_state),
-           fn other_strategy ->
-             other_strategy.__struct__ == AshAuthentication.Strategy.Password &&
-               other_strategy.registration_enabled?
-           end
-         ) do
-      nil ->
-        :ok
-
-      password_strategy ->
-        if has_confirmation_add_on?(dsl_state, password_strategy) do
-          :ok
-        else
-          {:error,
-           DslError.exception(
-             path: [:authentication, :strategies, strategy.name],
-             message: """
-             If you have an oauth2 strategy and a password strategy, you must also have a
-             confirmation add-on that monitors the password's identity field.
-
-             This is to prevent from account hijacking. If the field used in your password strategy is not
-             an email field, you can set `prevent_hijacking?: false` in your oauth strategy.
-
-             For more information, see the confirmation tutorial on hexdocs.
-             """
-           )}
-        end
+    with [_ | _] = password_strategy_names <- registering_password_strategy_names(dsl_state),
+         {identity_name, [_ | _] = unmonitored_fields} <-
+           unmonitored_upsert_fields(dsl_state, strategy) do
+      {:warn,
+       [hijack_warning(strategy, password_strategy_names, identity_name, unmonitored_fields)]}
+    else
+      _ -> :ok
     end
   end
 
-  defp has_confirmation_add_on?(dsl_state, password_strategy) do
-    Enum.any?(AshAuthentication.Info.authentication_add_ons(dsl_state), fn add_on ->
-      add_on.__struct__ == AshAuthentication.AddOn.Confirmation &&
-        password_strategy.identity_field in add_on.monitor_fields
-    end)
+  defp registering_password_strategy_names(dsl_state) do
+    dsl_state
+    |> AshAuthentication.Info.authentication_strategies()
+    |> Enum.filter(
+      &(&1.__struct__ == AshAuthentication.Strategy.Password and &1.registration_enabled?)
+    )
+    |> Enum.map(& &1.name)
+    |> Enum.sort()
   end
+
+  defp unmonitored_upsert_fields(dsl_state, strategy) do
+    with action when is_map(action) <-
+           Ash.Resource.Info.action(dsl_state, strategy.register_action_name),
+         identity_name when not is_nil(identity_name) <- Map.get(action, :upsert_identity),
+         identity when is_map(identity) <- Ash.Resource.Info.identity(dsl_state, identity_name) do
+      {identity_name, identity.keys -- monitored_fields(dsl_state)}
+    else
+      _ -> nil
+    end
+  end
+
+  defp monitored_fields(dsl_state) do
+    dsl_state
+    |> AshAuthentication.Info.authentication_add_ons()
+    |> Enum.filter(&(&1.__struct__ == AshAuthentication.AddOn.Confirmation))
+    |> Enum.flat_map(& &1.monitor_fields)
+  end
+
+  defp hijack_warning(strategy, password_strategy_names, identity_name, unmonitored_fields) do
+    fields = format_names(unmonitored_fields)
+
+    """
+    The `#{inspect(strategy.name)}` strategy on `#{inspect(strategy.resource)}` registers users by upserting on the `#{inspect(identity_name)}` identity, but no confirmation add-on monitors every field of that identity.
+
+    Unmonitored fields: #{fields}.
+    Password strategies which also register users: #{format_names(password_strategy_names)}.
+
+    An attacker can register a password account which carries the victim's
+    #{fields}. The victim's first sign-in through the provider then upserts into
+    that account.
+
+    Add a confirmation add-on which monitors #{fields}, or set
+    `prevent_hijacking? false` on the `#{inspect(strategy.name)}` strategy.
+    Confirmation proves ownership of an email address only, so it cannot protect
+    a field which holds anything else.
+
+    For more information, see the confirmation tutorial on hexdocs.
+    """
+  end
+
+  defp format_names(names), do: Enum.map_join(names, ", ", &"`#{inspect(&1)}`")
 end

--- a/lib/ash_authentication/validations.ex
+++ b/lib/ash_authentication/validations.ex
@@ -208,6 +208,25 @@ defmodule AshAuthentication.Validations do
   end
 
   @doc """
+  Combine several validation results into a single result.
+
+  Verifiers run more than one warning-producing check. A `with` chain would stop
+  at the first `{:warn, _}` and drop the rest, so collect them all instead.
+  """
+  @spec merge_warnings([:ok | {:warn, [String.t()]}]) :: :ok | {:warn, [String.t()]}
+  def merge_warnings(results) do
+    results
+    |> Enum.flat_map(fn
+      :ok -> []
+      {:warn, warnings} -> List.wrap(warnings)
+    end)
+    |> case do
+      [] -> :ok
+      warnings -> {:warn, warnings}
+    end
+  end
+
+  @doc """
   Collect compile-time warnings for an OAuth2/OIDC strategy.
 
   Returns `{:warn, messages}` (so the configuration still compiles) for the

--- a/test/ash_authentication/strategies/oauth2/verifier_test.exs
+++ b/test/ash_authentication/strategies/oauth2/verifier_test.exs
@@ -2,11 +2,134 @@
 #
 # SPDX-License-Identifier: MIT
 
+defmodule AshAuthentication.Strategy.OAuth2.VerifierFixture do
+  @moduledoc false
+
+  @doc """
+  Builds a user resource which pairs an oauth2 strategy with password
+  strategies, so `prevent_hijacking/2` has something to inspect.
+
+  `Spark.Test` collects diagnostics through the process dictionary, and the
+  verify hook runs in the parallel checker's process. A resource built at run
+  time therefore escapes the collector, so callers splice this at compile time.
+  """
+  def user_ast(module, domain, token, opts) do
+    password_order = Keyword.fetch!(opts, :password_order)
+    upsert_identity = Keyword.fetch!(opts, :upsert_identity)
+    monitor_fields = Keyword.get(opts, :monitor_fields, [:email])
+    confirmation? = Keyword.get(opts, :confirmation?, true)
+    prevent_hijacking? = Keyword.get(opts, :prevent_hijacking?, true)
+    registration_enabled? = Keyword.get(opts, :registration_enabled?, true)
+
+    quote do
+      defmodule unquote(module) do
+        @moduledoc false
+        use Ash.Resource,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshAuthentication],
+          domain: unquote(domain),
+          validate_domain_inclusion?: false
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:email, :ci_string, allow_nil?: false, public?: true)
+          attribute(:username, :ci_string, allow_nil?: false, public?: true)
+          attribute(:hashed_password, :string, allow_nil?: false, sensitive?: true)
+        end
+
+        actions do
+          defaults([:read])
+
+          read :sign_in_with_oauth2 do
+            argument(:user_info, :map, allow_nil?: false)
+            argument(:oauth_tokens, :map, allow_nil?: false)
+            prepare(AshAuthentication.Strategy.OAuth2.SignInPreparation)
+          end
+
+          create :register_with_oauth2 do
+            argument(:user_info, :map, allow_nil?: false)
+            argument(:oauth_tokens, :map, allow_nil?: false)
+            upsert?(true)
+            upsert_identity(unquote(upsert_identity))
+            change(AshAuthentication.GenerateTokenChange)
+
+            change(
+              {AshAuthentication.Strategy.OAuth2.UserInfoToAttributes,
+               fields: [:email, :username]}
+            )
+          end
+        end
+
+        identities do
+          identity(:unique_email, [:email], pre_check_with: unquote(domain))
+          identity(:unique_username, [:username], pre_check_with: unquote(domain))
+
+          identity(:unique_email_and_username, [:email, :username],
+            pre_check_with: unquote(domain)
+          )
+        end
+
+        authentication do
+          tokens do
+            enabled?(true)
+            token_resource(unquote(token))
+            signing_secret("Marty McFly in the past with the Delorean")
+            store_all_tokens?(true)
+            require_token_presence_for_authentication?(true)
+          end
+
+          add_ons do
+            if unquote(confirmation?) do
+              confirmation :confirm do
+                monitor_fields(unquote(monitor_fields))
+                require_interaction?(true)
+                sender(fn _user, _token, _opts -> :ok end)
+              end
+            end
+          end
+
+          strategies do
+            for password_strategy <- unquote(password_order) do
+              case password_strategy do
+                :email_password ->
+                  password :email_password do
+                    identity_field(:email)
+                    register_action_accept([:username])
+                  end
+
+                :username_password ->
+                  password :username_password do
+                    identity_field(:username)
+                    register_action_accept([:email])
+                  end
+              end
+            end
+
+            oauth2 do
+              client_id("client id")
+              client_secret("client secret")
+              redirect_uri("http://localhost/auth")
+              base_url("http://localhost")
+              authorize_url("http://localhost/authorize")
+              token_url("http://localhost/token")
+              user_url("http://localhost/user")
+              prevent_hijacking?(unquote(prevent_hijacking?))
+              registration_enabled?(unquote(registration_enabled?))
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
 defmodule AshAuthentication.Strategy.OAuth2.VerifierTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
   import Spark.Test
+
+  alias AshAuthentication.Strategy.OAuth2.VerifierFixture
 
   defmodule Domain do
     @moduledoc false
@@ -14,6 +137,162 @@ defmodule AshAuthentication.Strategy.OAuth2.VerifierTest do
 
     resources do
       allow_unregistered? true
+    end
+  end
+
+  defmodule Token do
+    @moduledoc false
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshAuthentication.TokenResource],
+      domain: AshAuthentication.Strategy.OAuth2.VerifierTest.Domain
+
+    token do
+      domain AshAuthentication.Strategy.OAuth2.VerifierTest.Domain
+    end
+  end
+
+  @hijack_warning "registers users by upserting on"
+
+  # Matches both this diagnostic and the one it replaced, so a `refute` also
+  # catches a spurious complaint from the previous single-candidate check.
+  @any_hijack_diagnostic "confirmation tutorial on hexdocs"
+
+  # `AshAuthentication.Info.authentication_strategies/1` returns strategies in
+  # reverse declaration order, so every case runs in both orders.
+  @orders [
+    email_first: [:email_password, :username_password],
+    username_first: [:username_password, :email_password]
+  ]
+
+  @cases [
+    every_unmonitored_field: [
+      upsert_identity: :unique_email_and_username,
+      monitor_fields: [:email]
+    ],
+    nothing_monitored: [upsert_identity: :unique_username, monitor_fields: [:email]],
+    no_confirmation: [upsert_identity: :unique_email, confirmation?: false],
+    all_monitored: [
+      upsert_identity: :unique_email_and_username,
+      monitor_fields: [:email, :username]
+    ],
+    uncovered_password_strategy: [upsert_identity: :unique_email, monitor_fields: [:email]],
+    hijacking_allowed: [
+      upsert_identity: :unique_username,
+      monitor_fields: [:email],
+      prevent_hijacking?: false
+    ],
+    registration_disabled: [
+      upsert_identity: :unique_username,
+      monitor_fields: [:email],
+      registration_enabled?: false
+    ],
+    no_registering_password_strategy: [
+      upsert_identity: :unique_username,
+      monitor_fields: [:email]
+    ]
+  ]
+
+  # The check emits a warning, but the version it replaced emitted an error
+  # which Spark downgrades to a warning. Both channels are collected so a
+  # `refute` cannot pass merely because the diagnostic took the other one.
+  for {order_name, order} <- @orders ++ [no_password_strategy: []],
+      {case_name, case_opts} <- @cases,
+      # The no-password-strategy case does not vary by declaration order.
+      case_name == :no_registering_password_strategy == (order_name == :no_password_strategy) do
+    opts = Keyword.merge(case_opts, password_order: order)
+
+    base =
+      Module.concat([
+        AshAuthentication.Strategy.OAuth2.VerifierTest.Resources,
+        Macro.camelize("#{case_name}_#{order_name}")
+      ])
+
+    warn_ast =
+      VerifierFixture.user_ast(
+        Module.concat(base, Warn),
+        AshAuthentication.Strategy.OAuth2.VerifierTest.Domain,
+        AshAuthentication.Strategy.OAuth2.VerifierTest.Token,
+        opts
+      )
+
+    error_ast =
+      VerifierFixture.user_ast(
+        Module.concat(base, Error),
+        AshAuthentication.Strategy.OAuth2.VerifierTest.Domain,
+        AshAuthentication.Strategy.OAuth2.VerifierTest.Token,
+        opts
+      )
+
+    def diagnostics(unquote(case_name), unquote(order_name)) do
+      warnings =
+        dsl_warnings do
+          unquote(warn_ast)
+        end
+
+      errors =
+        dsl_errors do
+          unquote(error_ast)
+        end
+
+      messages =
+        Enum.flat_map(warnings, fn {_module, payloads} ->
+          Enum.map(payloads, fn {message, _location} -> message end)
+        end) ++
+          Enum.flat_map(errors, fn {_module, collected} -> Enum.map(collected, & &1.message) end)
+
+      Enum.join(messages, "\n")
+    end
+  end
+
+  describe "prevent_hijacking/2" do
+    for {order_name, _order} <- @orders do
+      test "reports every unmonitored field of the upsert identity (#{order_name})" do
+        diagnostics = diagnostics(:every_unmonitored_field, unquote(order_name))
+
+        assert diagnostics =~ @hijack_warning
+        assert diagnostics =~ "`:unique_email_and_username`"
+        assert diagnostics =~ "Unmonitored fields: `:username`."
+
+        assert diagnostics =~
+                 "Password strategies which also register users: `:email_password`, `:username_password`."
+      end
+
+      test "warns when the upsert identity is not monitored at all (#{order_name})" do
+        diagnostics = diagnostics(:nothing_monitored, unquote(order_name))
+
+        assert diagnostics =~ @hijack_warning
+        assert diagnostics =~ "Unmonitored fields: `:username`."
+      end
+
+      test "warns when there is no confirmation add-on (#{order_name})" do
+        diagnostics = diagnostics(:no_confirmation, unquote(order_name))
+
+        assert diagnostics =~ @hijack_warning
+        assert diagnostics =~ "Unmonitored fields: `:email`."
+      end
+
+      test "stays silent when every upsert field is monitored (#{order_name})" do
+        refute diagnostics(:all_monitored, unquote(order_name)) =~ @any_hijack_diagnostic
+      end
+
+      test "stays silent when the uncovered password strategy cannot collide with the upsert (#{order_name})" do
+        refute diagnostics(:uncovered_password_strategy, unquote(order_name)) =~
+                 @any_hijack_diagnostic
+      end
+
+      test "stays silent when `prevent_hijacking?` is disabled (#{order_name})" do
+        refute diagnostics(:hijacking_allowed, unquote(order_name)) =~ @any_hijack_diagnostic
+      end
+
+      test "stays silent when registration is disabled (#{order_name})" do
+        refute diagnostics(:registration_disabled, unquote(order_name)) =~ @any_hijack_diagnostic
+      end
+    end
+
+    test "stays silent when no password strategy registers users" do
+      refute diagnostics(:no_registering_password_strategy, :no_password_strategy) =~
+               @any_hijack_diagnostic
     end
   end
 


### PR DESCRIPTION
Backport of the same fix to `stable-4.0`.

## The bug

`OAuth2.Verifier.prevent_hijacking/2` used `Enum.find/2` to select a
**single** registration-enabled password strategy, checked whether a
confirmation add-on monitored that one strategy's `identity_field`, and
returned `:ok` without inspecting any other candidate.

`Info.authentication_strategies/1` returns strategies in reverse
declaration order, so an identical configuration warned or stayed silent
purely on the order the strategies were declared in.

## What changed

**The check now keys on the register action's `upsert_identity`**, which is
the shape `MagicLink.Verifier` already uses. That is also what the
confirmation add-on's runtime guard keys on: the guard fires when the upsert
changes a monitored field, and the password strategies are never consulted.
The old predicate keyed on password identity fields, which is not what
decides whether the hijack is possible.

Registration-enabled password strategies remain the trigger, exactly as in
the magic link verifier. Every unmonitored field of the upsert identity is
reported at once, so an operator does not fix them one compile at a time.

The message names the strategy, the resource, the identity, the unmonitored
fields and the registering password strategies, so it is actionable without
reading the source.

**It returns `{:warn, _}` rather than `{:error, _}`.** Spark wraps its verify
phase in a `catch` that routes any raised `DslError` to `Spark.Warning.warn`,
so this check has never been able to fail a compile on any currently
installable stack. Returning a warning states the check's real authority
rather than depending on that downgrade to soften an error. `merge_warnings/1`
collects it alongside `oauth2_strategy_warnings/2` so a `with` chain cannot
drop either one.

`prevent_hijacking? false` and `registration_enabled? false` short-circuit
as before.

## Behaviour change

Which configurations warn moves in both directions:

- Configurations whose OAuth register action upserts on a **non-email**
  identity now warn where they were silent before. The old check could not
  see this case even when it was "working".
- Configurations whose extra password strategy **cannot collide with the
  upsert at all** no longer warn. The runtime confirmation guard already
  blocks that case, so the warning was noise.

The warning also states that confirmation proves ownership of an email
address only, so monitoring a non-email collision field does not make that
field safe — `prevent_hijacking? false` is the honest answer there.

## Difference from the `main` PR

On this line `prevent_hijacking/2` stays private, because nothing outside
`OAuth2.Verifier` calls it. On `main` the OIDC family calls it, so it is
public there.

Note that on this line `oidc`, `apple` and `slack` strategies never invoke
this check at all — their verifier chain goes through `Oidc.Verifier`, which
lacks the call. That gap is out of scope here and will be filed separately.

## Tests

There was no test coverage for this function on either line. The two
pre-existing tests in this file are kept unchanged.

The new tests run **every case in both declaration orders**, since the
ordering dependency is half the defect. They cover: two registration-enabled
password strategies with confirmation covering only part of the upsert
identity, all covered, none covered, `prevent_hijacking? false`, and
`registration_enabled? false`. Every fixture declares an oauth2 strategy, so
`prevent_hijacking/2` actually runs.

They use the `Spark.Test` helpers already used in this file, and collect
**both** the warning and the error channel, so a `refute` cannot pass merely
because a diagnostic took the other channel.

Against unfixed code 7 of the 15 new tests fail. Two of them — both
`username_first` — collect no hijack diagnostic at all, which is the
order-dependent silent miss reproduced directly.